### PR TITLE
Create unit tests for authentication, also abstracts firebase api services to allow for organization and better testing.

### DIFF
--- a/Sweat Social.xcodeproj/project.pbxproj
+++ b/Sweat Social.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		C536A1F62B7D13E800079DCC /* AuthPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1F52B7D13E800079DCC /* AuthPasswordView.swift */; };
 		C536A1F82B7D235B00079DCC /* AuthButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1F72B7D235B00079DCC /* AuthButtonView.swift */; };
 		C536A1FD2B7D2C4600079DCC /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1FC2B7D2C4600079DCC /* Extensions.swift */; };
+		C538E5132B8FE5400035FC15 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C538E5122B8FE5400035FC15 /* LoginTests.swift */; };
+		C538E5172B8FF3470035FC15 /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C538E5162B8FF3470035FC15 /* Helper.swift */; };
 		C5766A0A2B741B1800F898EA /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5766A092B741B1800F898EA /* LoginViewModel.swift */; };
 		C5766A0E2B741EF400F898EA /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5766A0D2B741EF400F898EA /* LoginView.swift */; };
 		C5F64D122B84323300A0454D /* ci_pre_xcodebuild.sh in Resources */ = {isa = PBXBuildFile; fileRef = C5F64D112B84323300A0454D /* ci_pre_xcodebuild.sh */; };
@@ -75,6 +77,8 @@
 		C536A1F52B7D13E800079DCC /* AuthPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthPasswordView.swift; sourceTree = "<group>"; };
 		C536A1F72B7D235B00079DCC /* AuthButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthButtonView.swift; sourceTree = "<group>"; };
 		C536A1FC2B7D2C4600079DCC /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		C538E5122B8FE5400035FC15 /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
+		C538E5162B8FF3470035FC15 /* Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helper.swift; sourceTree = "<group>"; };
 		C5766A092B741B1800F898EA /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		C5766A0D2B741EF400F898EA /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		C5F64D112B84323300A0454D /* ci_pre_xcodebuild.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = ci_pre_xcodebuild.sh; sourceTree = "<group>"; };
@@ -157,6 +161,8 @@
 			isa = PBXGroup;
 			children = (
 				0B6E8B1F2B6A9D0800455CB3 /* Sweat_SocialTests.swift */,
+				C538E5122B8FE5400035FC15 /* LoginTests.swift */,
+				C538E5162B8FF3470035FC15 /* Helper.swift */,
 			);
 			path = "Sweat SocialTests";
 			sourceTree = "<group>";
@@ -406,6 +412,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				0B6E8B202B6A9D0800455CB3 /* Sweat_SocialTests.swift in Sources */,
+				C538E5132B8FE5400035FC15 /* LoginTests.swift in Sources */,
+				C538E5172B8FF3470035FC15 /* Helper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -629,7 +637,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "ece49595.Sweat-SocialTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -650,7 +658,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "ece49595.Sweat-SocialTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -670,6 +678,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "ece49595.Sweat-SocialUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -689,6 +698,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "ece49595.Sweat-SocialUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sweat Social.xcodeproj/project.pbxproj
+++ b/Sweat Social.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0BE924612B7D8A23006F65F4 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE924602B7D8A23006F65F4 /* TabBarView.swift */; };
 		C507850C2B90DB5F00555C57 /* Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C507850B2B90DB5F00555C57 /* Protocol.swift */; };
 		C50785102B90E61500555C57 /* FirebaseAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C507850F2B90E61400555C57 /* FirebaseAuthService.swift */; };
+		C50785122B90F58500555C57 /* RegisterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50785112B90F58400555C57 /* RegisterTests.swift */; };
 		C50CA40D2B795FFB00AEACCA /* AuthHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CA40C2B795FFB00AEACCA /* AuthHeaderView.swift */; };
 		C50F11182B7AFEC80025FB0E /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50F11172B7AFEC80025FB0E /* AuthViewModel.swift */; };
 		C528A2342B76B75B00346B27 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = C528A2332B76B75B00346B27 /* FirebaseAuth */; };
@@ -70,6 +71,7 @@
 		0BE924602B7D8A23006F65F4 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		C507850B2B90DB5F00555C57 /* Protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocol.swift; sourceTree = "<group>"; };
 		C507850F2B90E61400555C57 /* FirebaseAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAuthService.swift; sourceTree = "<group>"; };
+		C50785112B90F58400555C57 /* RegisterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterTests.swift; sourceTree = "<group>"; };
 		C50CA40C2B795FFB00AEACCA /* AuthHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHeaderView.swift; sourceTree = "<group>"; };
 		C50F11172B7AFEC80025FB0E /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		C528A23B2B76B9E900346B27 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 				0B6E8B1F2B6A9D0800455CB3 /* Sweat_SocialTests.swift */,
 				C538E5122B8FE5400035FC15 /* LoginTests.swift */,
 				C538E5162B8FF3470035FC15 /* Helper.swift */,
+				C50785112B90F58400555C57 /* RegisterTests.swift */,
 			);
 			path = "Sweat SocialTests";
 			sourceTree = "<group>";
@@ -429,6 +432,7 @@
 			files = (
 				0B6E8B202B6A9D0800455CB3 /* Sweat_SocialTests.swift in Sources */,
 				C538E5132B8FE5400035FC15 /* LoginTests.swift in Sources */,
+				C50785122B90F58500555C57 /* RegisterTests.swift in Sources */,
 				C538E5172B8FF3470035FC15 /* Helper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sweat Social.xcodeproj/project.pbxproj
+++ b/Sweat Social.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		C536A1FD2B7D2C4600079DCC /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1FC2B7D2C4600079DCC /* Extensions.swift */; };
 		C538E5132B8FE5400035FC15 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C538E5122B8FE5400035FC15 /* LoginTests.swift */; };
 		C538E5172B8FF3470035FC15 /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C538E5162B8FF3470035FC15 /* Helper.swift */; };
+		C54CFB152B96318800DBC93B /* FirebaseFirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54CFB142B96318800DBC93B /* FirebaseFirestoreService.swift */; };
 		C5766A0A2B741B1800F898EA /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5766A092B741B1800F898EA /* LoginViewModel.swift */; };
 		C5766A0E2B741EF400F898EA /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5766A0D2B741EF400F898EA /* LoginView.swift */; };
 		C5F64D122B84323300A0454D /* ci_pre_xcodebuild.sh in Resources */ = {isa = PBXBuildFile; fileRef = C5F64D112B84323300A0454D /* ci_pre_xcodebuild.sh */; };
@@ -85,6 +86,7 @@
 		C536A1FC2B7D2C4600079DCC /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		C538E5122B8FE5400035FC15 /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		C538E5162B8FF3470035FC15 /* Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helper.swift; sourceTree = "<group>"; };
+		C54CFB142B96318800DBC93B /* FirebaseFirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseFirestoreService.swift; sourceTree = "<group>"; };
 		C5766A092B741B1800F898EA /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		C5766A0D2B741EF400F898EA /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		C5F64D112B84323300A0454D /* ci_pre_xcodebuild.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = ci_pre_xcodebuild.sh; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 			children = (
 				C507850B2B90DB5F00555C57 /* Protocol.swift */,
 				C507850F2B90E61400555C57 /* FirebaseAuthService.swift */,
+				C54CFB142B96318800DBC93B /* FirebaseFirestoreService.swift */,
 			);
 			path = FirebaseAPI;
 			sourceTree = "<group>";
@@ -410,6 +413,7 @@
 				0BE924612B7D8A23006F65F4 /* TabBarView.swift in Sources */,
 				C507850C2B90DB5F00555C57 /* Protocol.swift in Sources */,
 				C50F11182B7AFEC80025FB0E /* AuthViewModel.swift in Sources */,
+				C54CFB152B96318800DBC93B /* FirebaseFirestoreService.swift in Sources */,
 				C528A23C2B76B9E900346B27 /* User.swift in Sources */,
 				C5766A0A2B741B1800F898EA /* LoginViewModel.swift in Sources */,
 				0B6E8B112B6A9D0600455CB3 /* ContentView.swift in Sources */,

--- a/Sweat Social.xcodeproj/project.pbxproj
+++ b/Sweat Social.xcodeproj/project.pbxproj
@@ -16,11 +16,11 @@
 		0B6E8B2C2B6A9D0800455CB3 /* Sweat_SocialUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B6E8B2B2B6A9D0800455CB3 /* Sweat_SocialUITestsLaunchTests.swift */; };
 		0BE9245F2B7D828F006F65F4 /* References in Resources */ = {isa = PBXBuildFile; fileRef = 0BE9245E2B7D828F006F65F4 /* References */; };
 		0BE924612B7D8A23006F65F4 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE924602B7D8A23006F65F4 /* TabBarView.swift */; };
+		0BFE3C142B8BD7DD00689AA0 /* ActivityTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BFE3C132B8BD7DD00689AA0 /* ActivityTabView.swift */; };
+		0BFE3C162B8BDECA00689AA0 /* ActivityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BFE3C152B8BDECA00689AA0 /* ActivityViewModel.swift */; };
 		C507850C2B90DB5F00555C57 /* Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C507850B2B90DB5F00555C57 /* Protocol.swift */; };
 		C50785102B90E61500555C57 /* FirebaseAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C507850F2B90E61400555C57 /* FirebaseAuthService.swift */; };
 		C50785122B90F58500555C57 /* RegisterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50785112B90F58400555C57 /* RegisterTests.swift */; };
-		0BFE3C142B8BD7DD00689AA0 /* ActivityTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BFE3C132B8BD7DD00689AA0 /* ActivityTabView.swift */; };
-		0BFE3C162B8BDECA00689AA0 /* ActivityViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BFE3C152B8BDECA00689AA0 /* ActivityViewModel.swift */; };
 		C50CA40D2B795FFB00AEACCA /* AuthHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CA40C2B795FFB00AEACCA /* AuthHeaderView.swift */; };
 		C50F11182B7AFEC80025FB0E /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50F11172B7AFEC80025FB0E /* AuthViewModel.swift */; };
 		C527F1BF2B89235A00D0934F /* WorkoutLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C527F1BE2B89235A00D0934F /* WorkoutLogView.swift */; };
@@ -34,6 +34,7 @@
 		C531FD402B8C094F005CE16C /* ExcerciseLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C531FD3F2B8C094F005CE16C /* ExcerciseLogViewModel.swift */; };
 		C531FD422B8C18F9005CE16C /* AddExcerciseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C531FD412B8C18F9005CE16C /* AddExcerciseView.swift */; };
 		C531FD442B8C19E6005CE16C /* ExcerciseButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C531FD432B8C19E6005CE16C /* ExcerciseButtonView.swift */; };
+		C5329ACC2B96731F00D8ED3D /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5329ACB2B96731F00D8ED3D /* Errors.swift */; };
 		C536A1EB2B7D0D8C00079DCC /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1EA2B7D0D8C00079DCC /* RegisterView.swift */; };
 		C536A1ED2B7D0E9F00079DCC /* RegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1EC2B7D0E9F00079DCC /* RegisterViewModel.swift */; };
 		C536A1F42B7D13D900079DCC /* AuthTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1F32B7D13D900079DCC /* AuthTextFieldView.swift */; };
@@ -82,11 +83,11 @@
 		0B7D28302B6AAF6400066E36 /* Sweat-Social-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Sweat-Social-Info.plist"; sourceTree = SOURCE_ROOT; };
 		0BE9245E2B7D828F006F65F4 /* References */ = {isa = PBXFileReference; lastKnownFileType = text; path = References; sourceTree = "<group>"; };
 		0BE924602B7D8A23006F65F4 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+		0BFE3C132B8BD7DD00689AA0 /* ActivityTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTabView.swift; sourceTree = "<group>"; };
+		0BFE3C152B8BDECA00689AA0 /* ActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityViewModel.swift; sourceTree = "<group>"; };
 		C507850B2B90DB5F00555C57 /* Protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocol.swift; sourceTree = "<group>"; };
 		C507850F2B90E61400555C57 /* FirebaseAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAuthService.swift; sourceTree = "<group>"; };
 		C50785112B90F58400555C57 /* RegisterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterTests.swift; sourceTree = "<group>"; };
-		0BFE3C132B8BD7DD00689AA0 /* ActivityTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTabView.swift; sourceTree = "<group>"; };
-		0BFE3C152B8BDECA00689AA0 /* ActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityViewModel.swift; sourceTree = "<group>"; };
 		C50CA40C2B795FFB00AEACCA /* AuthHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHeaderView.swift; sourceTree = "<group>"; };
 		C50F11172B7AFEC80025FB0E /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		C527F1BE2B89235A00D0934F /* WorkoutLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutLogView.swift; sourceTree = "<group>"; };
@@ -99,6 +100,7 @@
 		C531FD3F2B8C094F005CE16C /* ExcerciseLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcerciseLogViewModel.swift; sourceTree = "<group>"; };
 		C531FD412B8C18F9005CE16C /* AddExcerciseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddExcerciseView.swift; sourceTree = "<group>"; };
 		C531FD432B8C19E6005CE16C /* ExcerciseButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcerciseButtonView.swift; sourceTree = "<group>"; };
+		C5329ACB2B96731F00D8ED3D /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		C536A1EA2B7D0D8C00079DCC /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
 		C536A1EC2B7D0E9F00079DCC /* RegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewModel.swift; sourceTree = "<group>"; };
 		C536A1F32B7D13D900079DCC /* AuthTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTextFieldView.swift; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 			children = (
 				C528A23B2B76B9E900346B27 /* User.swift */,
 				C531FD382B8BD7C3005CE16C /* Workout.swift */,
+				C5329ACB2B96731F00D8ED3D /* Errors.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -470,6 +473,7 @@
 				C8A5414E2B882056005AC444 /* GoalsView.swift in Sources */,
 				C531FD422B8C18F9005CE16C /* AddExcerciseView.swift in Sources */,
 				C531FD442B8C19E6005CE16C /* ExcerciseButtonView.swift in Sources */,
+				C5329ACC2B96731F00D8ED3D /* Errors.swift in Sources */,
 				C536A1EB2B7D0D8C00079DCC /* RegisterView.swift in Sources */,
 				C50785102B90E61500555C57 /* FirebaseAuthService.swift in Sources */,
 				C50CA40D2B795FFB00AEACCA /* AuthHeaderView.swift in Sources */,

--- a/Sweat Social.xcodeproj/project.pbxproj
+++ b/Sweat Social.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		0B6E8B2C2B6A9D0800455CB3 /* Sweat_SocialUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B6E8B2B2B6A9D0800455CB3 /* Sweat_SocialUITestsLaunchTests.swift */; };
 		0BE9245F2B7D828F006F65F4 /* References in Resources */ = {isa = PBXBuildFile; fileRef = 0BE9245E2B7D828F006F65F4 /* References */; };
 		0BE924612B7D8A23006F65F4 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE924602B7D8A23006F65F4 /* TabBarView.swift */; };
+		C507850C2B90DB5F00555C57 /* Protocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C507850B2B90DB5F00555C57 /* Protocol.swift */; };
+		C50785102B90E61500555C57 /* FirebaseAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C507850F2B90E61400555C57 /* FirebaseAuthService.swift */; };
 		C50CA40D2B795FFB00AEACCA /* AuthHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50CA40C2B795FFB00AEACCA /* AuthHeaderView.swift */; };
 		C50F11182B7AFEC80025FB0E /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50F11172B7AFEC80025FB0E /* AuthViewModel.swift */; };
 		C528A2342B76B75B00346B27 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = C528A2332B76B75B00346B27 /* FirebaseAuth */; };
@@ -66,6 +68,8 @@
 		0B7D28302B6AAF6400066E36 /* Sweat-Social-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "Sweat-Social-Info.plist"; sourceTree = SOURCE_ROOT; };
 		0BE9245E2B7D828F006F65F4 /* References */ = {isa = PBXFileReference; lastKnownFileType = text; path = References; sourceTree = "<group>"; };
 		0BE924602B7D8A23006F65F4 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+		C507850B2B90DB5F00555C57 /* Protocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Protocol.swift; sourceTree = "<group>"; };
+		C507850F2B90E61400555C57 /* FirebaseAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAuthService.swift; sourceTree = "<group>"; };
 		C50CA40C2B795FFB00AEACCA /* AuthHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthHeaderView.swift; sourceTree = "<group>"; };
 		C50F11172B7AFEC80025FB0E /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		C528A23B2B76B9E900346B27 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -136,6 +140,7 @@
 		0B6E8B0D2B6A9D0600455CB3 /* Sweat Social */ = {
 			isa = PBXGroup;
 			children = (
+				C507850A2B90DB3E00555C57 /* FirebaseAPI */,
 				C536A1FB2B7D2C2500079DCC /* Other */,
 				0B7D28302B6AAF6400066E36 /* Sweat-Social-Info.plist */,
 				C5766A032B7418A400F898EA /* Views */,
@@ -174,6 +179,15 @@
 				0B6E8B2B2B6A9D0800455CB3 /* Sweat_SocialUITestsLaunchTests.swift */,
 			);
 			path = "Sweat SocialUITests";
+			sourceTree = "<group>";
+		};
+		C507850A2B90DB3E00555C57 /* FirebaseAPI */ = {
+			isa = PBXGroup;
+			children = (
+				C507850B2B90DB5F00555C57 /* Protocol.swift */,
+				C507850F2B90E61400555C57 /* FirebaseAuthService.swift */,
+			);
+			path = FirebaseAPI;
 			sourceTree = "<group>";
 		};
 		C52C0E0A2B8525CB0070D707 /* Recovered References */ = {
@@ -391,12 +405,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				0BE924612B7D8A23006F65F4 /* TabBarView.swift in Sources */,
+				C507850C2B90DB5F00555C57 /* Protocol.swift in Sources */,
 				C50F11182B7AFEC80025FB0E /* AuthViewModel.swift in Sources */,
 				C528A23C2B76B9E900346B27 /* User.swift in Sources */,
 				C5766A0A2B741B1800F898EA /* LoginViewModel.swift in Sources */,
 				0B6E8B112B6A9D0600455CB3 /* ContentView.swift in Sources */,
 				C5766A0E2B741EF400F898EA /* LoginView.swift in Sources */,
 				C536A1EB2B7D0D8C00079DCC /* RegisterView.swift in Sources */,
+				C50785102B90E61500555C57 /* FirebaseAuthService.swift in Sources */,
 				C50CA40D2B795FFB00AEACCA /* AuthHeaderView.swift in Sources */,
 				C536A1F62B7D13E800079DCC /* AuthPasswordView.swift in Sources */,
 				C536A1FD2B7D2C4600079DCC /* Extensions.swift in Sources */,

--- a/Sweat Social/FirebaseAPI/FirebaseAuthService.swift
+++ b/Sweat Social/FirebaseAPI/FirebaseAuthService.swift
@@ -10,9 +10,22 @@ import FirebaseAuth
 
 
 class FirebaseAuthService: AuthProtocol {
+    
     func signIn(withEmail email: String, password: String, completion: @escaping (Error?) -> Void) {
         Auth.auth().signIn(withEmail: email, password: password) { (_, error) in
-                completion(error)
+            completion(error)
+        }
+    }
+    
+    func createUser(withEmail email: String, password: String, completion: @escaping (Result<String?,Error>) -> Void) {
+        Auth.auth().createUser(withEmail: email, password: password) { result, error in
+            if let error = error {
+                completion(.failure(error))
+            } else if let userId = result?.user.uid {
+                completion(.success(userId))
+            } else {
+                completion(.failure("Invalid User" as! Error))
+            }
         }
     }
 }

--- a/Sweat Social/FirebaseAPI/FirebaseAuthService.swift
+++ b/Sweat Social/FirebaseAPI/FirebaseAuthService.swift
@@ -1,0 +1,18 @@
+//
+//  FirebaseAuthService.swift
+//  Sweat Social
+//
+//  Created by Jack.Knox on 2024-02-29.
+//
+
+import Foundation
+import FirebaseAuth
+
+
+class FirebaseAuthService: AuthProtocol {
+    func signIn(withEmail email: String, password: String, completion: @escaping (Error?) -> Void) {
+        Auth.auth().signIn(withEmail: email, password: password) { (_, error) in
+                completion(error)
+        }
+    }
+}

--- a/Sweat Social/FirebaseAPI/FirebaseAuthService.swift
+++ b/Sweat Social/FirebaseAPI/FirebaseAuthService.swift
@@ -24,7 +24,7 @@ class FirebaseAuthService: AuthProtocol {
             } else if let userId = result?.user.uid {
                 completion(.success(userId))
             } else {
-                completion(.failure("Invalid User" as! Error))
+                completion(.failure(InvalidUserError()))
             }
         }
     }

--- a/Sweat Social/FirebaseAPI/FirebaseFirestoreService.swift
+++ b/Sweat Social/FirebaseAPI/FirebaseFirestoreService.swift
@@ -1,0 +1,31 @@
+//
+//  FirebaseFirestoreService.swift
+//  Sweat Social
+//
+//  Created by Jack.Knox on 2024-03-04.
+//
+
+import Foundation
+import FirebaseFirestore
+
+class FirebaseFirestoreService : FirestoreProtocol {
+    
+    func insertNewUser(id: String, name: String, email: String, completion: @escaping (Result<Void?, Error>) -> Void) {
+        let newUser = User(id: id,
+                           name: name,
+                           email: email,
+                           joined: Date().timeIntervalSince1970) // Firebase cannot store date as is, so this is a way to handle that
+        
+        let db = Firestore.firestore()
+        
+        db.collection("users")
+            .document(id)
+            .setData(newUser.asDictionary()) { error in
+                if let error = error {
+                    completion(.failure(error))
+                } else {
+                    completion(.success(()))
+                }
+            }
+    }
+}

--- a/Sweat Social/FirebaseAPI/FirebaseFirestoreService.swift
+++ b/Sweat Social/FirebaseAPI/FirebaseFirestoreService.swift
@@ -14,7 +14,8 @@ class FirebaseFirestoreService : FirestoreProtocol {
         let newUser = User(id: id,
                            name: name,
                            email: email,
-                           joined: Date().timeIntervalSince1970) // Firebase cannot store date as is, so this is a way to handle that
+                           joined: Date().timeIntervalSince1970,
+                           workout: []) // Firebase cannot store date as is, so this is a way to handle that
         
         let db = Firestore.firestore()
         

--- a/Sweat Social/FirebaseAPI/Protocol.swift
+++ b/Sweat Social/FirebaseAPI/Protocol.swift
@@ -1,0 +1,14 @@
+//
+//  AuthProtocol.swift
+//  Sweat Social
+//
+//  Created by Jack.Knox on 2024-02-29.
+//
+
+import Foundation
+import FirebaseAuth
+
+protocol AuthProtocol {
+    typealias completionHandler = (Error?) -> Void
+    func signIn(withEmail email: String, password: String, completion: @escaping completionHandler)
+}

--- a/Sweat Social/FirebaseAPI/Protocol.swift
+++ b/Sweat Social/FirebaseAPI/Protocol.swift
@@ -9,10 +9,10 @@ import Foundation
 import FirebaseAuth
 
 protocol AuthProtocol {
-    typealias completionHandler = (Error?) -> Void
-    typealias completionHandler2 = (Result<String?,Error>) -> Void
-    func signIn(withEmail email: String, password: String, completion: @escaping completionHandler)
-    func createUser(withEmail email: String, password: String, completion: @escaping completionHandler2)
+    typealias errorHandler = (Error?) -> Void
+    typealias completionHandler = (Result<String?,Error>) -> Void
+    func signIn(withEmail email: String, password: String, completion: @escaping errorHandler)
+    func createUser(withEmail email: String, password: String, completion: @escaping completionHandler)
 }
 
 protocol FirestoreProtocol {

--- a/Sweat Social/FirebaseAPI/Protocol.swift
+++ b/Sweat Social/FirebaseAPI/Protocol.swift
@@ -10,5 +10,7 @@ import FirebaseAuth
 
 protocol AuthProtocol {
     typealias completionHandler = (Error?) -> Void
+    typealias completionHandler2 = (Result<String?,Error>) -> Void
     func signIn(withEmail email: String, password: String, completion: @escaping completionHandler)
+    func createUser(withEmail email: String, password: String, completion: @escaping completionHandler2)
 }

--- a/Sweat Social/FirebaseAPI/Protocol.swift
+++ b/Sweat Social/FirebaseAPI/Protocol.swift
@@ -14,3 +14,7 @@ protocol AuthProtocol {
     func signIn(withEmail email: String, password: String, completion: @escaping completionHandler)
     func createUser(withEmail email: String, password: String, completion: @escaping completionHandler2)
 }
+
+protocol FirestoreProtocol {
+    func insertNewUser(id: String, name: String, email: String, completion: @escaping (Result<Void?, Error>) -> Void)
+}

--- a/Sweat Social/Models/Errors.swift
+++ b/Sweat Social/Models/Errors.swift
@@ -1,0 +1,12 @@
+//
+//  Errors.swift
+//  Sweat Social
+//
+//  Created by Jack.Knox on 2024-03-04.
+//
+
+import Foundation
+
+struct InvalidUserError: Error {
+    var localizedDescription: String = "Invalid User"
+}

--- a/Sweat Social/ViewModels/LoginViewModel.swift
+++ b/Sweat Social/ViewModels/LoginViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import FirebaseAuth
-class LoginViewViewModel: ObservableObject {
+class LoginViewModel: ObservableObject {
     @Published var email = ""
     @Published var password = ""
     @Published var errorMessage = ""

--- a/Sweat Social/ViewModels/LoginViewModel.swift
+++ b/Sweat Social/ViewModels/LoginViewModel.swift
@@ -7,12 +7,18 @@
 
 import Foundation
 import FirebaseAuth
+
+
 class LoginViewModel: ObservableObject {
     @Published var email = ""
     @Published var password = ""
     @Published var errorMessage = ""
     
-    init() {}
+    private let auth: AuthProtocol
+    
+    init(auth: AuthProtocol = FirebaseAuthService()) {
+        self.auth = auth
+    }
     
     func login() {
         guard validate() else {
@@ -22,8 +28,8 @@ class LoginViewModel: ObservableObject {
         // Try login
         // This throws User doesnt exist message upon failure, but doesn't actually check error message
         // At the time, this was too complex, and should be fixed as the app develops
-        Auth.auth().signIn(withEmail: email, password: password) { (_, error) in
-            if let error = error {
+        auth.signIn(withEmail: email, password: password) { (error) in
+            if error != nil {
                 self.errorMessage = "User does not exist"
             }
         }

--- a/Sweat Social/ViewModels/RegisterViewModel.swift
+++ b/Sweat Social/ViewModels/RegisterViewModel.swift
@@ -16,19 +16,26 @@ class RegisterViewModel: ObservableObject {
     @Published var confirmPassword = ""
     @Published var errorMessage = ""
     
-    init() {}
+    private let auth: AuthProtocol
+    
+    init(auth: AuthProtocol = FirebaseAuthService()) {
+        self.auth = auth
+    }
     
     func register() {
         guard validate() else {
             return
         }
         // Creates a user on firebase auth
-        Auth.auth().createUser(withEmail: email, password: password) { [weak self] result, error in
-            guard let userId = result?.user.uid else {
-                return
+        auth.createUser(withEmail: email, password: password) { result in
+            switch result {
+            case .success(let userId):
+                self.insertUserRecord(id: userId ?? "")
+            case .failure(let error):
+                self.errorMessage = error.localizedDescription
             }
             
-            self?.insertUserRecord(id: userId)
+            
         }
     }
     

--- a/Sweat Social/ViewModels/RegisterViewModel.swift
+++ b/Sweat Social/ViewModels/RegisterViewModel.swift
@@ -15,6 +15,8 @@ class RegisterViewModel: ObservableObject {
     @Published var password = ""
     @Published var confirmPassword = ""
     @Published var errorMessage = ""
+    @Published var userId = ""
+    
     
     private let auth: AuthProtocol
     private let firestore: FirestoreProtocol
@@ -32,7 +34,8 @@ class RegisterViewModel: ObservableObject {
         auth.createUser(withEmail: email, password: password) { [weak self] result in
             switch result {
             case .success(let userId):
-                self?.firestore.insertNewUser(id: userId ?? "", name: self?.name ?? "", email: self?.email ?? "") { firestoreResult in
+                self?.userId = userId ?? ""
+                self?.firestore.insertNewUser(id: self?.userId ?? "", name: self?.name ?? "", email: self?.email ?? "") { firestoreResult in
 
                     switch firestoreResult{
                     case .failure(let error):

--- a/Sweat Social/Views/LoginView.swift
+++ b/Sweat Social/Views/LoginView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Firebase
 
 struct LoginView: View {
-    @StateObject var viewModel = LoginViewViewModel()
+    @StateObject var viewModel = LoginViewModel()
     var body: some View {
         NavigationStack {
             ZStack {

--- a/Sweat Social/Views/RegisterView.swift
+++ b/Sweat Social/Views/RegisterView.swift
@@ -24,11 +24,15 @@ struct RegisterView: View {
                     Text("Register with us now")
                         .font(.system(size:26))
                         .padding(.bottom, 20)
-                    
+                        
                     if !viewModel.errorMessage.isEmpty {
                         Text(viewModel.errorMessage)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(nil)
+                            .frame(maxWidth:350)
                             
                     }
+                    
                     AuthTextFieldView(display: "Full Name",
                                        input: $viewModel.name)
                     AuthTextFieldView(display: "Email",

--- a/Sweat Social/Views/TabBarView.swift
+++ b/Sweat Social/Views/TabBarView.swift
@@ -9,35 +9,55 @@ import SwiftUI
 
 struct TabBar: View {
     var body: some View {
-        //AuthHeaderView()
-        TabView {
-            ActivityTabView()
-                .tabItem {
-                    Label("Social", systemImage: "message")
-                }
-                .badge(3)
+        ZStack {
             
-            Text("Calender")
-                .tabItem {
-                    Label("Calender", systemImage: "calendar")
-                }
+            
+            TabView {
+                ActivityTabView()
+                    .tabItem {
+                        Label("Social", systemImage: "message")
+                    }
+                    .badge(3)
                 
-            
-            WorkoutLogView()
-                .tabItem {
-                    Label("Log Workout", systemImage: "plus.circle.fill")
-                }
-            
-            GoalsView()
-                .tabItem {
-                    Label("Achievements", systemImage: "medal")
-
-                }
-            
-            Text("Profile")
-                .tabItem {
-                    Label("Profile", systemImage: "person.fill")
+                Text("Calender")
+                    .tabItem {
+                        Label("Calender", systemImage: "calendar")
+                    }
+                
+                
+                WorkoutLogView()
+                    .tabItem {
+                        Label("Log Workout", systemImage: "plus.circle.fill")
+                    }
+                
+                GoalsView()
+                    .tabItem {
+                        Label("Achievements", systemImage: "medal")
+                        
+                    }
+                
+                Text("Profile")
+                    .tabItem {
+                        Label("Profile", systemImage: "person.fill")
+                    }
             }
+            .padding(.top, 70)
+            
+            ZStack {
+                Rectangle()
+                    .foregroundColor(.black)
+                
+                Text("Sweat Social")
+                    .font(.custom("Futura-MediumItalic", size: 64))
+                    .fontWidth(.condensed)
+                    .foregroundStyle(.white)
+                    .baselineOffset(-135)
+                    .bold()
+                
+            }
+            .frame(width: UIScreen.main.bounds.width, height: 259)
+            .offset(y: -400)
+            
         }
     }
 }

--- a/Sweat Social/Views/WorkoutLogView.swift
+++ b/Sweat Social/Views/WorkoutLogView.swift
@@ -12,55 +12,57 @@ struct WorkoutLogView: View {
     
     var body: some View {
         NavigationStack {
-            ZStack {
-                VStack {
-                    ScrollView {
-                        if let workoutGroups = viewModel.workoutGroups {
-                            ForEach(workoutGroups) { group in
-                                WorkoutGroupButtonView(name: group.name)
-                            }
-                            .offset(y:50)
-                        }
-                    }
-                }
-                
-                ZStack{
-                    
-                    Text("Your Workout")
-                        .frame(maxWidth: .infinity, alignment: .center)
-                    
-                    HStack {
-                        Spacer()
-                        Button {
-                            viewModel.addWorkoutForm.toggle()
-                        } label: {
-                            ZStack {
-                                RoundedRectangle(cornerRadius: 15)
-                                    .foregroundColor(.black)
-                                Text("+")
-                                    .foregroundColor(.white)
-                                    .font(.system(size: 20))
-                                    .fontWeight(.bold)
-                            }
-                            .frame(width: 39, height: 26)
-                            .padding()
+            VStack {
+                ZStack {
+                    VStack {
+                        ZStack{
                             
+                            Text("Your Workout")
+                                .frame(maxWidth: .infinity, alignment: .center)
+                            
+                            HStack {
+                                Spacer()
+                                Button {
+                                    viewModel.addWorkoutForm.toggle()
+                                } label: {
+                                    ZStack {
+                                        RoundedRectangle(cornerRadius: 15)
+                                            .foregroundColor(.black)
+                                        Text("+")
+                                            .foregroundColor(.white)
+                                            .font(.system(size: 20))
+                                            .fontWeight(.bold)
+                                    }
+                                    .frame(width: 39, height: 26)
+                                    .padding()
+                                    
+                                }
+                                //.padding(8)
+                                
+                            }
                         }
-                        .padding(8)
                         
+                        ScrollView {
+                            if let workoutGroups = viewModel.workoutGroups {
+                                ForEach(workoutGroups) { group in
+                                    WorkoutGroupButtonView(name: group.name)
+                                }
+                                
+                            }
+                        }
                     }
-                }
-                .offset(y:-340)
 
-                if viewModel.addWorkoutForm {
-                    ZStack {
-                        AddWorkoutView(showForm: $viewModel.addWorkoutForm, action: viewModel.addWorkoutGroup)
+                    if viewModel.addWorkoutForm {
+                        ZStack {
+                            AddWorkoutView(showForm: $viewModel.addWorkoutForm, action: viewModel.addWorkoutGroup)
+                        }
                     }
+                    
                 }
-                
             }
-            
+            .padding(.top,40)
         }
+        
     }
 }
 

--- a/Sweat SocialTests/Helper.swift
+++ b/Sweat SocialTests/Helper.swift
@@ -17,13 +17,37 @@ public func generateRandomString(length: Int) -> String {
 //}
 
 class MockFirebaseAuthServiceSuccess: AuthProtocol {
-    func signIn(withEmail email: String, password: String, completion: @escaping (Error?) -> Void) {
-        completion(nil)
+    func createUser(withEmail email: String, password: String, completion: @escaping completionHandler) {
+        completion(.success(password)) // Password may seem illogical to return here, but it is serving the purpose of mocking a user id. Another option would be to generate a user id outside of this func and passing it in, and returning, but this wouldn't fit AuthProtocol
     }
+    
+    func signIn(withEmail email: String, password: String, completion: @escaping errorHandler) {
+        completion(nil)
+        
+    }
+    
 }
 
 class MockFirebaseAuthServiceFailed: AuthProtocol {
-    func signIn(withEmail email: String, password: String, completion: @escaping (Error?) -> Void) {
+    func createUser(withEmail email: String, password: String, completion: @escaping completionHandler) {
+        let userInfo = [NSLocalizedDescriptionKey: "Failure creating user."]
+        completion(.failure(NSError(domain: "RegisterError", code: 123, userInfo:userInfo)))
+    }
+    
+    func signIn(withEmail email: String, password: String, completion: @escaping errorHandler) {
         completion(NSError(domain: "LoginError", code: 123, userInfo:nil))
+    }
+}
+
+class MockFirebaseFirestoreServiceSuccess: FirestoreProtocol {
+    func insertNewUser(id: String, name: String, email: String, completion: @escaping (Result<Void?, Error>) -> Void) {
+        completion(.success(()))
+    }
+}
+
+class MockFirebaseFirestoreServiceFailed: FirestoreProtocol {
+    func insertNewUser(id: String, name: String, email: String, completion: @escaping (Result<Void?, Error>) -> Void) {
+        let userInfo = [NSLocalizedDescriptionKey: "Failure connecting to Firestore."]
+        completion(.failure(NSError(domain: "FirebaseError", code: 123, userInfo: userInfo)))
     }
 }

--- a/Sweat SocialTests/Helper.swift
+++ b/Sweat SocialTests/Helper.swift
@@ -1,0 +1,16 @@
+//
+//  Helper.swift
+//  Sweat SocialTests
+//
+//  Created by Jack.Knox on 2024-02-28.
+//
+
+import Foundation
+
+
+//struct TestHelpers {
+public func generateRandomString(length: Int) -> String {
+    let characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    return String((0..<length).map { _ in characters.randomElement()! })
+}
+//}

--- a/Sweat SocialTests/Helper.swift
+++ b/Sweat SocialTests/Helper.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+@testable import Sweat_Social
 
 
 //struct TestHelpers {
@@ -14,3 +15,15 @@ public func generateRandomString(length: Int) -> String {
     return String((0..<length).map { _ in characters.randomElement()! })
 }
 //}
+
+class MockFirebaseAuthServiceSuccess: AuthProtocol {
+    func signIn(withEmail email: String, password: String, completion: @escaping (Error?) -> Void) {
+        completion(nil)
+    }
+}
+
+class MockFirebaseAuthServiceFailed: AuthProtocol {
+    func signIn(withEmail email: String, password: String, completion: @escaping (Error?) -> Void) {
+        completion(NSError(domain: "LoginError", code: 123, userInfo:nil))
+    }
+}

--- a/Sweat SocialTests/LoginTests.swift
+++ b/Sweat SocialTests/LoginTests.swift
@@ -1,0 +1,98 @@
+//
+//  LoginTests.swift
+//  Sweat SocialTests
+//
+//  Created by Jack.Knox on 2024-02-28.
+//
+
+import XCTest
+
+@testable import Sweat_Social
+
+final class LoginTests: XCTestCase {
+    
+    func test_LoginViewModel_email_shouldBeEmpty() {
+        let viewModel = LoginViewModel()
+        
+        XCTAssertEqual(viewModel.email, "")
+        
+    }
+    
+    func test_LoginViewModel_password_shouldBeEmpty() {
+        let viewModel = LoginViewModel()
+        
+        XCTAssertEqual(viewModel.password, "")
+        
+    }
+    
+    func test_LoginViewModel_errorMessage_shouldBeEmpty() {
+        let viewModel = LoginViewModel()
+        
+        XCTAssertEqual(viewModel.errorMessage, "")
+        
+    }
+    func test_LoginViewModel_email_enteredCorrectly() {
+        // Given
+        let email: String = "test@mail.com"
+        
+        //When
+        let viewModel = LoginViewModel()
+        viewModel.email = email
+        
+        //Then
+        XCTAssertEqual(viewModel.email, email)
+        
+    }
+    
+    func test_LoginViewModel_password_enteredCorrectly() {
+        // Given
+        let password: String = generateRandomString(length: Int.random(in: 6...14))
+        
+        //When
+        let viewModel = LoginViewModel()
+        viewModel.password = password
+        
+        //Then
+        XCTAssertEqual(viewModel.password, password)
+        
+    }
+    
+    func test_LoginViewModel_errorMessage_enteredCorrectly() {
+        let errorMessage: String = "Hello Testing World!"
+        
+        let viewModel = LoginViewModel()
+        viewModel.errorMessage = errorMessage
+        
+        XCTAssertEqual(viewModel.errorMessage, errorMessage)
+    }
+    
+    func test_LoginViewModel_login_blankFields() {
+        let numberOfSpaces = Int.random(in:1...10)
+        let email = String(repeating: " ",count: numberOfSpaces)
+        let password = String(repeating: " ",count: numberOfSpaces)
+        
+        let viewModel = LoginViewModel()
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.login()
+        
+        XCTAssertEqual(viewModel.errorMessage, "Please fill in all fields.")
+    }
+    
+    func test_LoginViewModel_login_validEmail() {
+        let numberOfSpaces = Int.random(in:1...10)
+        let email = generateRandomString(length: Int.random(in: 6...16))
+        let password = generateRandomString(length: Int.random(in: 6...16))
+        
+        let viewModel = LoginViewModel()
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.login()
+        
+        XCTAssertEqual(viewModel.errorMessage, "Please enter a valid email.")
+        
+        
+    }
+    
+
+}

--- a/Sweat SocialTests/LoginTests.swift
+++ b/Sweat SocialTests/LoginTests.swift
@@ -11,21 +11,21 @@ import XCTest
 
 final class LoginTests: XCTestCase {
     
-    func test_LoginViewModel_email_shouldBeEmpty() {
+    func test_LoginViewModel_email_shouldBeEmptyOnInitialization() {
         let viewModel = LoginViewModel()
         
         XCTAssertEqual(viewModel.email, "")
         
     }
     
-    func test_LoginViewModel_password_shouldBeEmpty() {
+    func test_LoginViewModel_password_shouldBeEmptyOnInitialization() {
         let viewModel = LoginViewModel()
         
         XCTAssertEqual(viewModel.password, "")
         
     }
     
-    func test_LoginViewModel_errorMessage_shouldBeEmpty() {
+    func test_LoginViewModel_errorMessage_shouldBeEmptyOnIntiInitialization() {
         let viewModel = LoginViewModel()
         
         XCTAssertEqual(viewModel.errorMessage, "")
@@ -94,5 +94,28 @@ final class LoginTests: XCTestCase {
         
     }
     
+    func test_LoginViewModel_login_succesfulLogin() {
+        let email = "test@email.com"
+        let password = generateRandomString(length: Int.random(in:1...10))
+        let viewModel = LoginViewModel(auth: MockFirebaseAuthServiceSuccess())
+        
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.login()
+        
+        XCTAssertEqual(viewModel.errorMessage,"")
+    }
+    
+    func test_LoginViewModel_login_failedLogin() {
+        let email = "test@email.com"
+        let password = generateRandomString(length: Int.random(in:1...10))
+        let viewModel = LoginViewModel(auth: MockFirebaseAuthServiceFailed())
+        
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.login()
+        
+        XCTAssertEqual(viewModel.errorMessage,"User does not exist")
+    }
 
 }

--- a/Sweat SocialTests/RegisterTests.swift
+++ b/Sweat SocialTests/RegisterTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import Sweat_Social
 
 final class RegisterTests: XCTestCase {
-
+    
     func test_RegisterViewModel_email_shouldBeEmptyOnInitialization() {
         let viewModel = RegisterViewModel()
         
@@ -123,11 +123,11 @@ final class RegisterTests: XCTestCase {
         XCTAssertEqual(viewModel.errorMessage, "Please fill in all fields.")
     }
     
-    func test_RegisterViewModel_Register_validEmail() {
+    func test_RegisterViewModel_Register_invalidEmail() {
         let numberOfSpaces = Int.random(in:1...10)
         let email = generateRandomString(length: Int.random(in: 6...16))
         let password = generateRandomString(length: Int.random(in: 6...16))
-        let confirmPassword = generateRandomString(length: Int.random(in: 6...16))
+        let confirmPassword = password
         let name = generateRandomString(length: Int.random(in: 6...16))
         
         let viewModel = RegisterViewModel()
@@ -180,28 +180,61 @@ final class RegisterTests: XCTestCase {
         
         
     }
-    /*
-    func test_RegisterViewModel_Register_succesfulRegister() {
+    
+    func test_RegisterViewModel_Register_succesfulRegister_succesfulFirestore() {
         let email = "test@email.com"
-        let password = generateRandomString(length: Int.random(in:1...10))
-        let viewModel = RegisterViewModel(auth: MockFirebaseAuthServiceSuccess())
+        let password = generateRandomString(length: Int.random(in:6...10))
+        let confirmPassword = password
+        let name = generateRandomString(length: Int.random(in: 7...12))
         
+        let viewModel = RegisterViewModel(auth: MockFirebaseAuthServiceSuccess(), firestore: MockFirebaseFirestoreServiceSuccess())
         viewModel.email = email
         viewModel.password = password
-        viewModel.Register()
+        viewModel.name = name
+        viewModel.confirmPassword = confirmPassword
         
+        viewModel.register()
+        
+        XCTAssertEqual(viewModel.userId, password) // Password is used to mock userId, look at helper
+        XCTAssertEqual(viewModel.password, password)
+        XCTAssertEqual(viewModel.email, email)
+        XCTAssertEqual(viewModel.name, name)
         XCTAssertEqual(viewModel.errorMessage,"")
     }
     
     func test_RegisterViewModel_Register_failedRegister() {
         let email = "test@email.com"
-        let password = generateRandomString(length: Int.random(in:1...10))
-        let viewModel = RegisterViewModel(auth: MockFirebaseAuthServiceFailed())
+        let password = generateRandomString(length: Int.random(in:6...10))
+        let confirmPassword = password
+        let name = generateRandomString(length: Int.random(in: 6...16))
         
+        let viewModel = RegisterViewModel(auth: MockFirebaseAuthServiceFailed(), firestore: MockFirebaseFirestoreServiceSuccess()) // Firestore should be irrelevant, if code works correctly then it shouldnt be used
         viewModel.email = email
         viewModel.password = password
-        viewModel.Register()
+        viewModel.name = name
+        viewModel.confirmPassword = confirmPassword
         
-        XCTAssertEqual(viewModel.errorMessage,"User does not exist")
-    }*/
+        viewModel.register()
+        
+        //XCTAssertEqual(viewModel.password, password)
+        XCTAssertEqual(viewModel.errorMessage,"Failure creating user.")
+    }
+    
+    func test_RegisterViewModel_Register_succesfulRegister_failedFirestore() {
+        let email = "test@email.com"
+        let password = generateRandomString(length: Int.random(in:6...10))
+        let confirmPassword = password
+        let name = generateRandomString(length: Int.random(in: 6...16))
+        
+        let viewModel = RegisterViewModel(auth: MockFirebaseAuthServiceSuccess(), firestore: MockFirebaseFirestoreServiceFailed())
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.name = name
+        viewModel.confirmPassword = confirmPassword
+        
+        viewModel.register()
+        
+        //XCTAssertEqual(viewModel.password, password)
+        XCTAssertEqual(viewModel.errorMessage,"Failure connecting to Firestore.")
+    }
 }

--- a/Sweat SocialTests/RegisterTests.swift
+++ b/Sweat SocialTests/RegisterTests.swift
@@ -1,0 +1,207 @@
+//
+//  RegisterTests.swift
+//  Sweat SocialTests
+//
+//  Created by Jack.Knox on 2024-02-29.
+//
+
+import XCTest
+@testable import Sweat_Social
+
+final class RegisterTests: XCTestCase {
+
+    func test_RegisterViewModel_email_shouldBeEmptyOnInitialization() {
+        let viewModel = RegisterViewModel()
+        
+        XCTAssertEqual(viewModel.email, "")
+        
+    }
+    
+    func test_RegisterViewModel_password_shouldBeEmptyOnInitialization() {
+        let viewModel = RegisterViewModel()
+        
+        XCTAssertEqual(viewModel.password, "")
+        
+    }
+    
+    func test_RegisterViewModel_errorMessage_shouldBeEmptyOnIntiInitialization() {
+        let viewModel = RegisterViewModel()
+        
+        XCTAssertEqual(viewModel.errorMessage, "")
+        
+    }
+    
+    func test_RegisterViewModel_name_shouldBeEmptyOnIntiInitialization() {
+        let viewModel = RegisterViewModel()
+        
+        XCTAssertEqual(viewModel.name, "")
+        
+    }
+    
+    func test_RegisterViewModel_confirmPassword_shouldBeEmptyOnIntiInitialization() {
+        let viewModel = RegisterViewModel()
+        
+        XCTAssertEqual(viewModel.confirmPassword, "")
+        
+    }
+    
+    func test_RegisterViewModel_email_enteredCorrectly() {
+        // Given
+        let email: String = "test@mail.com"
+        
+        //When
+        let viewModel = RegisterViewModel()
+        viewModel.email = email
+        
+        //Then
+        XCTAssertEqual(viewModel.email, email)
+        
+    }
+    
+    func test_RegisterViewModel_password_enteredCorrectly() {
+        // Given
+        let password: String = generateRandomString(length: Int.random(in: 6...14))
+        
+        //When
+        let viewModel = RegisterViewModel()
+        viewModel.password = password
+        
+        //Then
+        XCTAssertEqual(viewModel.password, password)
+        
+    }
+    
+    func test_RegisterViewModel_confirmPassword_enteredCorrectly() {
+        // Given
+        let confirmPassword: String = generateRandomString(length: Int.random(in: 6...14))
+        
+        //When
+        let viewModel = RegisterViewModel()
+        viewModel.confirmPassword = confirmPassword
+        
+        //Then
+        XCTAssertEqual(viewModel.confirmPassword, confirmPassword)
+        
+    }
+    
+    func test_RegisterViewModel_name_enteredCorrectly() {
+        // Given
+        let name: String = generateRandomString(length: Int.random(in: 6...14))
+        
+        //When
+        let viewModel = RegisterViewModel()
+        viewModel.name = name
+        
+        //Then
+        XCTAssertEqual(viewModel.name, name)
+        
+    }
+    
+    func test_RegisterViewModel_errorMessage_enteredCorrectly() {
+        let errorMessage: String = "Hello Testing World!"
+        
+        let viewModel = RegisterViewModel()
+        viewModel.errorMessage = errorMessage
+        
+        XCTAssertEqual(viewModel.errorMessage, errorMessage)
+    }
+    
+    func test_RegisterViewModel_Register_blankFields() {
+        let numberOfSpaces = Int.random(in:1...10)
+        let email = String(repeating: " ",count: numberOfSpaces)
+        let password = String(repeating: " ",count: numberOfSpaces)
+        let confirmPassword = String(repeating: " ",count: numberOfSpaces)
+        let name = String(repeating: " ",count: numberOfSpaces)
+        let viewModel = RegisterViewModel()
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.confirmPassword = confirmPassword
+        viewModel.name = name
+        
+        viewModel.register()
+        
+        XCTAssertEqual(viewModel.errorMessage, "Please fill in all fields.")
+    }
+    
+    func test_RegisterViewModel_Register_validEmail() {
+        let numberOfSpaces = Int.random(in:1...10)
+        let email = generateRandomString(length: Int.random(in: 6...16))
+        let password = generateRandomString(length: Int.random(in: 6...16))
+        let confirmPassword = generateRandomString(length: Int.random(in: 6...16))
+        let name = generateRandomString(length: Int.random(in: 6...16))
+        
+        let viewModel = RegisterViewModel()
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.name = name
+        viewModel.confirmPassword = confirmPassword
+        
+        viewModel.register()
+        
+        XCTAssertEqual(viewModel.errorMessage, "Please enter a valid email.")
+        
+        
+    }
+    
+    func test_RegisterViewModel_Register_passwordOverSixChars() {
+        let numberOfSpaces = Int.random(in:1...10)
+        let email = "test@email.com"
+        let password = generateRandomString(length: Int.random(in: 2...5))
+        let confirmPassword = generateRandomString(length: Int.random(in: 2...5))
+        let name = generateRandomString(length: Int.random(in: 6...16))
+        
+        let viewModel = RegisterViewModel()
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.name = name
+        viewModel.confirmPassword = confirmPassword
+        
+        viewModel.register()
+        
+        XCTAssertEqual(viewModel.errorMessage, "Password must be at least 6 characters.")
+    }
+    
+    func test_RegisterViewModel_Register_passWordsNotEqual() {
+        let numberOfSpaces = Int.random(in:1...10)
+        let email = "test@email.com"
+        let password = "password"
+        let confirmPassword = "password2"
+        let name = generateRandomString(length: Int.random(in: 6...16))
+        
+        let viewModel = RegisterViewModel()
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.name = name
+        viewModel.confirmPassword = confirmPassword
+        
+        viewModel.register()
+        
+        XCTAssertEqual(viewModel.errorMessage, "Passwords do not match.")
+        
+        
+    }
+    /*
+    func test_RegisterViewModel_Register_succesfulRegister() {
+        let email = "test@email.com"
+        let password = generateRandomString(length: Int.random(in:1...10))
+        let viewModel = RegisterViewModel(auth: MockFirebaseAuthServiceSuccess())
+        
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.Register()
+        
+        XCTAssertEqual(viewModel.errorMessage,"")
+    }
+    
+    func test_RegisterViewModel_Register_failedRegister() {
+        let email = "test@email.com"
+        let password = generateRandomString(length: Int.random(in:1...10))
+        let viewModel = RegisterViewModel(auth: MockFirebaseAuthServiceFailed())
+        
+        viewModel.email = email
+        viewModel.password = password
+        viewModel.Register()
+        
+        XCTAssertEqual(viewModel.errorMessage,"User does not exist")
+    }*/
+}


### PR DESCRIPTION
This adds unit tests for authentication, specifically for the login and register view models. It is not 100% exhaustive, but it covers a lot, and will likely be all that gets done for these files within the scope of class, and resolves #38. It also abstracts the firebase services called, which is better organized, but also allows for unit testing through mocking of these services.