### PR TITLE
First version of fully function workout logging screen. Builds upon previous pull requests. Closes #32

### DIFF
--- a/Sweat Social.xcodeproj/project.pbxproj
+++ b/Sweat Social.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		C53A75C12B9BE14A008338B6 /* SetsLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C53A75C02B9BE149008338B6 /* SetsLogView.swift */; };
 		C54A04482B9789A4000ADCAD /* WorkoutHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54A04472B9789A3000ADCAD /* WorkoutHeaderView.swift */; };
 		C54CFB152B96318800DBC93B /* FirebaseFirestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54CFB142B96318800DBC93B /* FirebaseFirestoreService.swift */; };
+		C54F8D8E2BB07EB300F3DF15 /* WorkoutViewManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54F8D8D2BB07EB300F3DF15 /* WorkoutViewManagerView.swift */; };
 		C550D8BB2BAA4B99004AB0C9 /* AddSetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C550D8BA2BAA4B99004AB0C9 /* AddSetView.swift */; };
 		C5766A0A2B741B1800F898EA /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5766A092B741B1800F898EA /* LoginViewModel.swift */; };
 		C5766A0E2B741EF400F898EA /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5766A0D2B741EF400F898EA /* LoginView.swift */; };
@@ -117,6 +118,7 @@
 		C53A75C02B9BE149008338B6 /* SetsLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetsLogView.swift; sourceTree = "<group>"; };
 		C54A04472B9789A3000ADCAD /* WorkoutHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutHeaderView.swift; sourceTree = "<group>"; };
 		C54CFB142B96318800DBC93B /* FirebaseFirestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseFirestoreService.swift; sourceTree = "<group>"; };
+		C54F8D8D2BB07EB300F3DF15 /* WorkoutViewManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutViewManagerView.swift; sourceTree = "<group>"; };
 		C550D8BA2BAA4B99004AB0C9 /* AddSetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSetView.swift; sourceTree = "<group>"; };
 		C5766A092B741B1800F898EA /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		C5766A0D2B741EF400F898EA /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
@@ -277,6 +279,7 @@
 				C531FD3C2B8C00C6005CE16C /* WorkoutHelperViews */,
 				C536A1F02B7D128200079DCC /* AuthHelperViews */,
 				0B6E8B102B6A9D0600455CB3 /* ContentView.swift */,
+				C54F8D8D2BB07EB300F3DF15 /* WorkoutViewManagerView.swift */,
 				C532A8212BAF8C3A00E672B4 /* ExcerciseLogView.swift */,
 				0BFE3C132B8BD7DD00689AA0 /* ActivityTabView.swift */,
 				C8A5414D2B882056005AC444 /* GoalsView.swift */,
@@ -474,6 +477,7 @@
 				C53935E72BA9D63D003228F9 /* SetsLogViewModel.swift in Sources */,
 				C53A75C12B9BE14A008338B6 /* SetsLogView.swift in Sources */,
 				C532A8262BAF99BF00E672B4 /* ExcerciseButtonView.swift in Sources */,
+				C54F8D8E2BB07EB300F3DF15 /* WorkoutViewManagerView.swift in Sources */,
 				C5F38B2B2B8952D80033B5C6 /* AddWorkoutView.swift in Sources */,
 				C527F1BF2B89235A00D0934F /* WorkoutLogView.swift in Sources */,
 				C550D8BB2BAA4B99004AB0C9 /* AddSetView.swift in Sources */,

--- a/Sweat Social.xcodeproj/project.pbxproj
+++ b/Sweat Social.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		C532A8222BAF8C3B00E672B4 /* ExcerciseLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C532A8212BAF8C3A00E672B4 /* ExcerciseLogView.swift */; };
 		C532A8242BAF8F0100E672B4 /* ExcerciseLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C532A8232BAF8F0100E672B4 /* ExcerciseLogViewModel.swift */; };
 		C532A8262BAF99BF00E672B4 /* ExcerciseButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C532A8252BAF99BF00E672B4 /* ExcerciseButtonView.swift */; };
+		C5344EEF2BB30A3A00DF4936 /* DeleteConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5344EEE2BB30A3A00DF4936 /* DeleteConfirmationView.swift */; };
 		C536A1EB2B7D0D8C00079DCC /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1EA2B7D0D8C00079DCC /* RegisterView.swift */; };
 		C536A1ED2B7D0E9F00079DCC /* RegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1EC2B7D0E9F00079DCC /* RegisterViewModel.swift */; };
 		C536A1F42B7D13D900079DCC /* AuthTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1F32B7D13D900079DCC /* AuthTextFieldView.swift */; };
@@ -107,6 +108,7 @@
 		C532A8212BAF8C3A00E672B4 /* ExcerciseLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcerciseLogView.swift; sourceTree = "<group>"; };
 		C532A8232BAF8F0100E672B4 /* ExcerciseLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcerciseLogViewModel.swift; sourceTree = "<group>"; };
 		C532A8252BAF99BF00E672B4 /* ExcerciseButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcerciseButtonView.swift; sourceTree = "<group>"; };
+		C5344EEE2BB30A3A00DF4936 /* DeleteConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteConfirmationView.swift; sourceTree = "<group>"; };
 		C536A1EA2B7D0D8C00079DCC /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
 		C536A1EC2B7D0E9F00079DCC /* RegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewModel.swift; sourceTree = "<group>"; };
 		C536A1F32B7D13D900079DCC /* AuthTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTextFieldView.swift; sourceTree = "<group>"; };
@@ -251,6 +253,7 @@
 				C53935EA2BA9F3E4003228F9 /* SetButtonView.swift */,
 				C550D8BA2BAA4B99004AB0C9 /* AddSetView.swift */,
 				C532A8252BAF99BF00E672B4 /* ExcerciseButtonView.swift */,
+				C5344EEE2BB30A3A00DF4936 /* DeleteConfirmationView.swift */,
 			);
 			path = WorkoutHelperViews;
 			sourceTree = "<group>";
@@ -509,6 +512,7 @@
 				C536A1F42B7D13D900079DCC /* AuthTextFieldView.swift in Sources */,
 				C536A1F82B7D235B00079DCC /* AuthButtonView.swift in Sources */,
 				C527F1C12B89247B00D0934F /* WorkoutLogViewModel.swift in Sources */,
+				C5344EEF2BB30A3A00DF4936 /* DeleteConfirmationView.swift in Sources */,
 				C536A1ED2B7D0E9F00079DCC /* RegisterViewModel.swift in Sources */,
 				0B6E8B0F2B6A9D0600455CB3 /* Sweat_SocialApp.swift in Sources */,
 			);

--- a/Sweat Social.xcodeproj/project.pbxproj
+++ b/Sweat Social.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		C528A2342B76B75B00346B27 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = C528A2332B76B75B00346B27 /* FirebaseAuth */; };
 		C528A2362B76B75B00346B27 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = C528A2352B76B75B00346B27 /* FirebaseFirestore */; };
 		C528A23C2B76B9E900346B27 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = C528A23B2B76B9E900346B27 /* User.swift */; };
+		C531534D2BB1C73000604987 /* WorkoutViewManagerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C531534C2BB1C73000604987 /* WorkoutViewManagerViewModel.swift */; };
 		C531FD392B8BD7C3005CE16C /* Workout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C531FD382B8BD7C3005CE16C /* Workout.swift */; };
 		C531FD3B2B8BFCC0005CE16C /* WorkoutGroupButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C531FD3A2B8BFCC0005CE16C /* WorkoutGroupButtonView.swift */; };
 		C5329ACC2B96731F00D8ED3D /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5329ACB2B96731F00D8ED3D /* Errors.swift */; };
@@ -99,6 +100,7 @@
 		C527F1C02B89247B00D0934F /* WorkoutLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutLogViewModel.swift; sourceTree = "<group>"; };
 		C528A23B2B76B9E900346B27 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		C5304A142B83BE3B00DA755E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Other/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		C531534C2BB1C73000604987 /* WorkoutViewManagerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutViewManagerViewModel.swift; sourceTree = "<group>"; };
 		C531FD382B8BD7C3005CE16C /* Workout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workout.swift; sourceTree = "<group>"; };
 		C531FD3A2B8BFCC0005CE16C /* WorkoutGroupButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutGroupButtonView.swift; sourceTree = "<group>"; };
 		C5329ACB2B96731F00D8ED3D /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
@@ -297,6 +299,7 @@
 			children = (
 				C5766A092B741B1800F898EA /* LoginViewModel.swift */,
 				C50F11172B7AFEC80025FB0E /* AuthViewModel.swift */,
+				C531534C2BB1C73000604987 /* WorkoutViewManagerViewModel.swift */,
 				C536A1EC2B7D0E9F00079DCC /* RegisterViewModel.swift */,
 				0BFE3C152B8BDECA00689AA0 /* ActivityViewModel.swift */,
 				C527F1C02B89247B00D0934F /* WorkoutLogViewModel.swift */,
@@ -479,6 +482,7 @@
 				C532A8262BAF99BF00E672B4 /* ExcerciseButtonView.swift in Sources */,
 				C54F8D8E2BB07EB300F3DF15 /* WorkoutViewManagerView.swift in Sources */,
 				C5F38B2B2B8952D80033B5C6 /* AddWorkoutView.swift in Sources */,
+				C531534D2BB1C73000604987 /* WorkoutViewManagerViewModel.swift in Sources */,
 				C527F1BF2B89235A00D0934F /* WorkoutLogView.swift in Sources */,
 				C550D8BB2BAA4B99004AB0C9 /* AddSetView.swift in Sources */,
 				0BE924612B7D8A23006F65F4 /* TabBarView.swift in Sources */,

--- a/Sweat Social.xcodeproj/project.pbxproj
+++ b/Sweat Social.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		C531FD392B8BD7C3005CE16C /* Workout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C531FD382B8BD7C3005CE16C /* Workout.swift */; };
 		C531FD3B2B8BFCC0005CE16C /* WorkoutGroupButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C531FD3A2B8BFCC0005CE16C /* WorkoutGroupButtonView.swift */; };
 		C5329ACC2B96731F00D8ED3D /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5329ACB2B96731F00D8ED3D /* Errors.swift */; };
+		C532A8222BAF8C3B00E672B4 /* ExcerciseLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C532A8212BAF8C3A00E672B4 /* ExcerciseLogView.swift */; };
+		C532A8242BAF8F0100E672B4 /* ExcerciseLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C532A8232BAF8F0100E672B4 /* ExcerciseLogViewModel.swift */; };
+		C532A8262BAF99BF00E672B4 /* ExcerciseButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C532A8252BAF99BF00E672B4 /* ExcerciseButtonView.swift */; };
 		C536A1EB2B7D0D8C00079DCC /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1EA2B7D0D8C00079DCC /* RegisterView.swift */; };
 		C536A1ED2B7D0E9F00079DCC /* RegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1EC2B7D0E9F00079DCC /* RegisterViewModel.swift */; };
 		C536A1F42B7D13D900079DCC /* AuthTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C536A1F32B7D13D900079DCC /* AuthTextFieldView.swift */; };
@@ -98,6 +101,9 @@
 		C531FD382B8BD7C3005CE16C /* Workout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workout.swift; sourceTree = "<group>"; };
 		C531FD3A2B8BFCC0005CE16C /* WorkoutGroupButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutGroupButtonView.swift; sourceTree = "<group>"; };
 		C5329ACB2B96731F00D8ED3D /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		C532A8212BAF8C3A00E672B4 /* ExcerciseLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcerciseLogView.swift; sourceTree = "<group>"; };
+		C532A8232BAF8F0100E672B4 /* ExcerciseLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcerciseLogViewModel.swift; sourceTree = "<group>"; };
+		C532A8252BAF99BF00E672B4 /* ExcerciseButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcerciseButtonView.swift; sourceTree = "<group>"; };
 		C536A1EA2B7D0D8C00079DCC /* RegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterView.swift; sourceTree = "<group>"; };
 		C536A1EC2B7D0E9F00079DCC /* RegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewModel.swift; sourceTree = "<group>"; };
 		C536A1F32B7D13D900079DCC /* AuthTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTextFieldView.swift; sourceTree = "<group>"; };
@@ -240,6 +246,7 @@
 				C54A04472B9789A3000ADCAD /* WorkoutHeaderView.swift */,
 				C53935EA2BA9F3E4003228F9 /* SetButtonView.swift */,
 				C550D8BA2BAA4B99004AB0C9 /* AddSetView.swift */,
+				C532A8252BAF99BF00E672B4 /* ExcerciseButtonView.swift */,
 			);
 			path = WorkoutHelperViews;
 			sourceTree = "<group>";
@@ -270,6 +277,7 @@
 				C531FD3C2B8C00C6005CE16C /* WorkoutHelperViews */,
 				C536A1F02B7D128200079DCC /* AuthHelperViews */,
 				0B6E8B102B6A9D0600455CB3 /* ContentView.swift */,
+				C532A8212BAF8C3A00E672B4 /* ExcerciseLogView.swift */,
 				0BFE3C132B8BD7DD00689AA0 /* ActivityTabView.swift */,
 				C8A5414D2B882056005AC444 /* GoalsView.swift */,
 				0BE924602B7D8A23006F65F4 /* TabBarView.swift */,
@@ -290,6 +298,7 @@
 				0BFE3C152B8BDECA00689AA0 /* ActivityViewModel.swift */,
 				C527F1C02B89247B00D0934F /* WorkoutLogViewModel.swift */,
 				C53935E62BA9D63D003228F9 /* SetsLogViewModel.swift */,
+				C532A8232BAF8F0100E672B4 /* ExcerciseLogViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -464,11 +473,13 @@
 				C53935EB2BA9F3E4003228F9 /* SetButtonView.swift in Sources */,
 				C53935E72BA9D63D003228F9 /* SetsLogViewModel.swift in Sources */,
 				C53A75C12B9BE14A008338B6 /* SetsLogView.swift in Sources */,
+				C532A8262BAF99BF00E672B4 /* ExcerciseButtonView.swift in Sources */,
 				C5F38B2B2B8952D80033B5C6 /* AddWorkoutView.swift in Sources */,
 				C527F1BF2B89235A00D0934F /* WorkoutLogView.swift in Sources */,
 				C550D8BB2BAA4B99004AB0C9 /* AddSetView.swift in Sources */,
 				0BE924612B7D8A23006F65F4 /* TabBarView.swift in Sources */,
 				C507850C2B90DB5F00555C57 /* Protocol.swift in Sources */,
+				C532A8222BAF8C3B00E672B4 /* ExcerciseLogView.swift in Sources */,
 				C50F11182B7AFEC80025FB0E /* AuthViewModel.swift in Sources */,
 				C54CFB152B96318800DBC93B /* FirebaseFirestoreService.swift in Sources */,
 				0BFE3C142B8BD7DD00689AA0 /* ActivityTabView.swift in Sources */,
@@ -483,6 +494,7 @@
 				C50785102B90E61500555C57 /* FirebaseAuthService.swift in Sources */,
 				C50CA40D2B795FFB00AEACCA /* AuthHeaderView.swift in Sources */,
 				C54A04482B9789A4000ADCAD /* WorkoutHeaderView.swift in Sources */,
+				C532A8242BAF8F0100E672B4 /* ExcerciseLogViewModel.swift in Sources */,
 				C536A1F62B7D13E800079DCC /* AuthPasswordView.swift in Sources */,
 				C536A1FD2B7D2C4600079DCC /* Extensions.swift in Sources */,
 				0BFE3C162B8BDECA00689AA0 /* ActivityViewModel.swift in Sources */,

--- a/Sweat Social/FirebaseAPI/FirebaseFirestoreService.swift
+++ b/Sweat Social/FirebaseAPI/FirebaseFirestoreService.swift
@@ -8,6 +8,9 @@
 import Foundation
 import FirebaseFirestore
 
+// This contains the functions used to communicate with firestore
+// Allows for dependency injection
+// Purpose of each function should be self explanatory based on name
 class FirebaseFirestoreService : FirestoreProtocol {
     static var db = Firestore.firestore()
     static var userCollection = "users"

--- a/Sweat Social/FirebaseAPI/FirebaseFirestoreService.swift
+++ b/Sweat Social/FirebaseAPI/FirebaseFirestoreService.swift
@@ -65,9 +65,29 @@ class FirebaseFirestoreService : FirestoreProtocol {
                 }
             }
         }
-        
     }
     
+    func deleteWorkout(userId: String, workoutToDelete: WorkoutExcercise, exerciseToDelete: WorkoutExcercise?, completion: @escaping (Result<Void?, Error>) -> Void) {
+        print("Here")
+        var doc = FirebaseFirestoreService.db.collection(FirebaseFirestoreService.userCollection)
+            .document(userId)
+            .collection(FirebaseFirestoreService.WorkoutCategoriesCollection)
+            .document(workoutToDelete.id)
+        
+        if let exerciseToDelete = exerciseToDelete {
+            doc = doc.collection(FirebaseFirestoreService.ExcerciseCollection)
+                .document(exerciseToDelete.id)
+        }
+
+        doc.delete { error in
+            if let error = error {
+                completion(.failure(error))
+            } else {
+                completion(.success(()))
+            }
+        }
+    }
+
     func insertSet(userId: String, workout: String, excercise: String, reps: Int, weight: Int, completion: @escaping (Result<Void?, Error>) -> Void){
         
         let document = FirebaseFirestoreService.db

--- a/Sweat Social/FirebaseAPI/FirebaseFirestoreService.swift
+++ b/Sweat Social/FirebaseAPI/FirebaseFirestoreService.swift
@@ -33,7 +33,9 @@ class FirebaseFirestoreService : FirestoreProtocol {
     }
     
     func insertWorkout(userId: String,newWorkoutCategory: WorkoutExcercise, newExcercise: WorkoutExcercise?, completion: @escaping (Result<Void?, Error>) -> Void) {
+
         var toAdd = newWorkoutCategory
+        
         
         var doc = FirebaseFirestoreService.db.collection(FirebaseFirestoreService.userCollection)
             .document(userId)

--- a/Sweat Social/FirebaseAPI/Protocol.swift
+++ b/Sweat Social/FirebaseAPI/Protocol.swift
@@ -26,7 +26,9 @@ protocol FirestoreProtocol {
     func deleteWorkout(userId: String, workoutToDelete: WorkoutExcercise, exerciseToDelete: WorkoutExcercise?, completion: @escaping (Result<Void?, Error>) -> Void)
     
     func insertSet(userId: String, workout: String, excercise: String, reps: Int, weight: Int, completion: @escaping (Result<Void?, Error>) -> Void)
-
+    
+    func deleteSet(userId: String, workout: String, excercise: String, index: Int, completion: @escaping (Result<Void?, Error>) -> Void)
+    
     func fetchWorkouts(userId: String, workout: String?, completion: @escaping (Result<[WorkoutExcercise], Error>) -> Void)
     
     func fetchSets(userId: String, workout: String, excercise: String, completion: @escaping (Result<Sets?, Error>) -> Void)

--- a/Sweat Social/FirebaseAPI/Protocol.swift
+++ b/Sweat Social/FirebaseAPI/Protocol.swift
@@ -23,6 +23,8 @@ protocol FirestoreProtocol {
     
     func insertWorkout(userId: String,newWorkoutCategory: WorkoutExcercise, newExcercise: WorkoutExcercise?, completion: @escaping (Result<Void?, Error>) -> Void)
     
+    func deleteWorkout(userId: String, workoutToDelete: WorkoutExcercise, exerciseToDelete: WorkoutExcercise?, completion: @escaping (Result<Void?, Error>) -> Void)
+    
     func insertSet(userId: String, workout: String, excercise: String, reps: Int, weight: Int, completion: @escaping (Result<Void?, Error>) -> Void)
 
     func fetchWorkouts(userId: String, workout: String?, completion: @escaping (Result<[WorkoutExcercise], Error>) -> Void)

--- a/Sweat Social/Models/Errors.swift
+++ b/Sweat Social/Models/Errors.swift
@@ -14,6 +14,7 @@ struct InvalidUserError: Error {
 enum CustomErrors: Error {
     case noCurrentUser
     case existingWorkout
+    case unknownError
 }
 
 struct NoCurrentUser: Error {
@@ -22,4 +23,8 @@ struct NoCurrentUser: Error {
 
 struct WorkoutExists: Error {
     let message = "This workout category already exists"
+}
+
+struct UnknownError: Error {
+    let message = "Unknown cause of Error"
 }

--- a/Sweat Social/ViewModels/ExcerciseLogViewModel.swift
+++ b/Sweat Social/ViewModels/ExcerciseLogViewModel.swift
@@ -1,0 +1,89 @@
+//
+//  ExcerciseLogViewModel.swift
+//  Sweat Social
+//
+//  Created by Jack.Knox on 2024-03-23.
+//
+
+import Foundation
+import FirebaseAuth
+import FirebaseFirestore
+
+class ExcerciseLogViewModel: ObservableObject {
+    @Published var userId: String
+    @Published var addExcerciseForm = false
+    @Published var excerciseList: [WorkoutExcercise] = []
+    @Published var workout: WorkoutExcercise? = nil
+    
+    
+    private let firestore: FirestoreProtocol
+    private let auth: AuthProtocol
+    
+    
+    init(auth: AuthProtocol = FirebaseAuthService(),
+         firestore: FirestoreProtocol = FirebaseFirestoreService()) {
+        self.auth = auth
+        self.firestore = firestore
+        self.userId = auth.currentUser
+    }
+    
+    
+    func addExcercise(excerciseName: String){
+        let dateAdded = Date().timeIntervalSince1970
+        
+        let newExcercise = WorkoutExcercise(id: excerciseName, dateAdded: dateAdded)
+        
+        guard let workout = self.workout else {
+            print("No workout provided")
+            return
+        }
+        
+        firestore.insertWorkout(userId: self.userId, newWorkoutCategory: workout, newExcercise: newExcercise) { [weak self] result in
+            guard self != nil else { return }
+            
+            if case let .failure(error) = result {
+                if error is WorkoutExists {
+                    print("This workout already exists")
+                } else {
+                    print(error.localizedDescription)
+                }
+            }
+        }
+        
+    }
+    
+    func fetchExcercises() {
+        guard let workout = self.workout else {
+            print("No workout provided")
+            return
+        }
+        
+        firestore.fetchWorkouts(userId: self.userId, workout: workout.id) { [weak self] result in
+            switch result {
+            case .failure(let error):
+                print(error.localizedDescription)
+            case .success(let excerciseList):
+                self?.excerciseList = excerciseList
+            }
+            
+        }
+    }
+    
+    func fetchSets(excercise: String, completion: @escaping (Sets?) -> Void) {
+        guard let workout = self.workout else {
+            print("No workout provided")
+            completion(nil)
+            return
+        }
+        
+        firestore.fetchSets(userId: self.userId, workout: workout.id, excercise: excercise) { result in
+            switch result {
+            case .failure(let error):
+                print(error.localizedDescription)
+            case .success(let sets):
+                completion(sets)
+            }
+        }
+    }
+    
+}

--- a/Sweat Social/ViewModels/ExcerciseLogViewModel.swift
+++ b/Sweat Social/ViewModels/ExcerciseLogViewModel.swift
@@ -9,20 +9,21 @@ import Foundation
 import FirebaseAuth
 import FirebaseFirestore
 
+//View model for excercise log view
 class ExcerciseLogViewModel: ObservableObject {
     @Published var userId: String
-    @Published var addExcerciseForm = false
-    @Published var excerciseList: [WorkoutExcercise] = []
-    @Published var workout: WorkoutExcercise? = nil
+    @Published var addExcerciseForm = false // Controls add excercise popup
+    @Published var excerciseList: [WorkoutExcercise] = [] // Excercises to display
+    @Published var workout: WorkoutExcercise? = nil // Associated workout
     @Published var errorMessage = ""
-    @Published var toDelete: WorkoutExcercise? = nil
-    @Published var deleteSuccess = false
+    @Published var toDelete: WorkoutExcercise? = nil // Excercise pending deletion, also controls confirmation popup
+    @Published var deleteSuccess = false // dismisses popup
     
     
     private let firestore: FirestoreProtocol
     private let auth: AuthProtocol
     
-    
+    // Initilize firebase auth and firestore
     init(auth: AuthProtocol = FirebaseAuthService(),
          firestore: FirestoreProtocol = FirebaseFirestoreService()) {
         self.auth = auth
@@ -30,8 +31,9 @@ class ExcerciseLogViewModel: ObservableObject {
         self.userId = auth.currentUser
     }
     
-    
+    // Adds excercise using firestore api
     func addExcercise(excerciseName: String){
+        // Validates input
         guard validate(input: excerciseName) else {
             return
         }
@@ -61,6 +63,7 @@ class ExcerciseLogViewModel: ObservableObject {
         
     }
     
+    // Fetch excercise calling firestore api
     func fetchExcercises() {
         guard let workout = self.workout else {
             print("No workout provided")
@@ -78,6 +81,7 @@ class ExcerciseLogViewModel: ObservableObject {
         }
     }
     
+    // Delete excercise using firestore api
     func deleteExcercise() {
         guard let toDelete = toDelete, let workout = workout else {
             return
@@ -94,6 +98,7 @@ class ExcerciseLogViewModel: ObservableObject {
         }
     }
     
+    // Fetch sets using firestore api
     func fetchSets(excercise: String, completion: @escaping (Sets?) -> Void) {
         guard let workout = self.workout else {
             print("No workout provided")
@@ -111,6 +116,7 @@ class ExcerciseLogViewModel: ObservableObject {
         }
     }
     
+    // Private func to validate input
     private func validate(input: String) -> Bool {
 
         guard input.count >= 3 && input.count <= 30 else {

--- a/Sweat Social/ViewModels/ExcerciseLogViewModel.swift
+++ b/Sweat Social/ViewModels/ExcerciseLogViewModel.swift
@@ -15,6 +15,8 @@ class ExcerciseLogViewModel: ObservableObject {
     @Published var excerciseList: [WorkoutExcercise] = []
     @Published var workout: WorkoutExcercise? = nil
     @Published var errorMessage = ""
+    @Published var toDelete: WorkoutExcercise? = nil
+    @Published var deleteSuccess = false
     
     
     private let firestore: FirestoreProtocol
@@ -76,6 +78,22 @@ class ExcerciseLogViewModel: ObservableObject {
         }
     }
     
+    func deleteExcercise() {
+        guard let toDelete = toDelete, let workout = workout else {
+            return
+        }
+        
+        firestore.deleteWorkout(userId: self.userId, workoutToDelete: workout, exerciseToDelete: toDelete) { [weak self] result in
+            switch result {
+            case .failure(let error):
+                print(error.localizedDescription)
+            default:
+                self?.toDelete = nil
+                return
+            }
+        }
+    }
+    
     func fetchSets(excercise: String, completion: @escaping (Sets?) -> Void) {
         guard let workout = self.workout else {
             print("No workout provided")
@@ -95,8 +113,8 @@ class ExcerciseLogViewModel: ObservableObject {
     
     private func validate(input: String) -> Bool {
 
-        guard input.count >= 3 && input.count <= 20 else {
-            self.errorMessage = "Input must be between 3 and 20 characters."
+        guard input.count >= 3 && input.count <= 30 else {
+            self.errorMessage = "Input must be between 3 and 30 characters."
             return false
             
         }

--- a/Sweat Social/ViewModels/ExcerciseLogViewModel.swift
+++ b/Sweat Social/ViewModels/ExcerciseLogViewModel.swift
@@ -14,6 +14,7 @@ class ExcerciseLogViewModel: ObservableObject {
     @Published var addExcerciseForm = false
     @Published var excerciseList: [WorkoutExcercise] = []
     @Published var workout: WorkoutExcercise? = nil
+    @Published var errorMessage = ""
     
     
     private let firestore: FirestoreProtocol
@@ -29,12 +30,16 @@ class ExcerciseLogViewModel: ObservableObject {
     
     
     func addExcercise(excerciseName: String){
+        guard validate(input: excerciseName) else {
+            return
+        }
+        
         let dateAdded = Date().timeIntervalSince1970
         
         let newExcercise = WorkoutExcercise(id: excerciseName, dateAdded: dateAdded)
         
         guard let workout = self.workout else {
-            print("No workout provided")
+            print("No workout provided.")
             return
         }
         
@@ -43,10 +48,12 @@ class ExcerciseLogViewModel: ObservableObject {
             
             if case let .failure(error) = result {
                 if error is WorkoutExists {
-                    print("This workout already exists")
+                    self?.errorMessage = "This excercise already exists."
                 } else {
-                    print(error.localizedDescription)
+                    self?.errorMessage = error.localizedDescription
                 }
+            } else {
+                self?.errorMessage = ""
             }
         }
         
@@ -86,4 +93,22 @@ class ExcerciseLogViewModel: ObservableObject {
         }
     }
     
+    private func validate(input: String) -> Bool {
+
+        guard input.count >= 3 && input.count <= 20 else {
+            self.errorMessage = "Input must be between 3 and 20 characters."
+            return false
+            
+        }
+        
+        let allowedCharacterSet = CharacterSet.letters.union(.whitespaces)
+        guard input.rangeOfCharacter(from: allowedCharacterSet.inverted) == nil else {
+            self.errorMessage = "Invalid characters in input."
+            return false
+        }
+
+        
+        return true
+        
+    }
 }

--- a/Sweat Social/ViewModels/SetsLogViewModel.swift
+++ b/Sweat Social/ViewModels/SetsLogViewModel.swift
@@ -14,6 +14,7 @@ class SetsLogViewModel: ObservableObject {
     @Published var workout: String = ""
     @Published var excercise: String = ""
     @Published var sets: Sets? = nil
+    @Published var errorMessage = ""
     
     private let firestore: FirestoreProtocol
     private let auth: AuthProtocol
@@ -26,15 +27,22 @@ class SetsLogViewModel: ObservableObject {
     }
     
     
-    func addSet(repsInput: Int, weightInput: Int){
+    func addSet(repsInput: String, weightInput: String){
+        guard validate(input: repsInput) && validate(input: weightInput) else {
+            return
+        }
+         
+        guard let reps = Int(repsInput), let weight = Int(weightInput) else {
+            return
+        }
         
-        firestore.insertSet(userId: self.userId, workout: self.workout, excercise: self.excercise, reps: repsInput, weight: weightInput) { [weak self] result in
+        firestore.insertSet(userId: self.userId, workout: self.workout, excercise: self.excercise, reps: Int(reps), weight: Int(weight)) { [weak self] result in
             guard self != nil else {
                 return
             }
             
             if case let .failure(error) = result {
-                    print(error.localizedDescription)
+                self?.errorMessage = error.localizedDescription
             }
         }
         fetchSets()
@@ -49,6 +57,21 @@ class SetsLogViewModel: ObservableObject {
                 self?.sets = sets
             }
         }
+    }
+    
+    private func validate(input: String) -> Bool {
+        guard input.rangeOfCharacter(from: CharacterSet.letters.inverted) != nil else {
+            self.errorMessage = "Only numeric characters allowewd."
+            return false
+        }
+        
+        guard input.count <= 3 else {
+            self.errorMessage = "Input must be at most a 3 digit number."
+            return false
+        }
+        
+        return true
+        
     }
     
     

--- a/Sweat Social/ViewModels/SetsLogViewModel.swift
+++ b/Sweat Social/ViewModels/SetsLogViewModel.swift
@@ -15,6 +15,8 @@ class SetsLogViewModel: ObservableObject {
     @Published var excercise: String = ""
     @Published var sets: Sets? = nil
     @Published var errorMessage = ""
+    @Published var toDelete: Int? = nil
+    @Published var deleteSuccess = false
     
     private let firestore: FirestoreProtocol
     private let auth: AuthProtocol
@@ -46,6 +48,24 @@ class SetsLogViewModel: ObservableObject {
             }
         }
         fetchSets()
+    }
+    
+    func deleteSet() {
+        guard let toDelete = toDelete else {
+            return
+        }
+        
+        firestore.deleteSet(userId: self.userId, workout: self.workout, excercise: self.excercise, index: toDelete) { [weak self] result in
+            guard self != nil else {
+                return
+            }
+            
+            if case let .failure(error) = result {
+                print(error.localizedDescription)
+            } else {
+                self?.toDelete = nil
+            }
+        }
     }
     
     func fetchSets() {

--- a/Sweat Social/ViewModels/SetsLogViewModel.swift
+++ b/Sweat Social/ViewModels/SetsLogViewModel.swift
@@ -8,19 +8,23 @@ import Foundation
 import FirebaseAuth
 import FirebaseFirestore
 
+
+//View model for set view
 class SetsLogViewModel: ObservableObject {
     @Published var userId: String
-    @Published var addSetForm = false
-    @Published var workout: String = ""
-    @Published var excercise: String = ""
-    @Published var sets: Sets? = nil
+    @Published var addSetForm = false // Var to trigger add set popup
+    @Published var workout: String = "" // Workout associated with the set
+    @Published var excercise: String = "" // Excercise associated with the set
+    @Published var sets: Sets? = nil // Sets to display in view
     @Published var errorMessage = ""
-    @Published var toDelete: Int? = nil
-    @Published var deleteSuccess = false
+    @Published var toDelete: Int? = nil // If delete is triggered, this value is updated, which displays confirmation view
+    @Published var deleteSuccess = false // Used to dismiss delete popup
+    @Published var firstFetch = true // Used to minimize number of calls to firestore, pass in sets from excercise view, and initialize snapshot on first add or delete
     
     private let firestore: FirestoreProtocol
     private let auth: AuthProtocol
     
+    // Initialize firestore and firebase auth
     init(auth: AuthProtocol = FirebaseAuthService(),
          firestore: FirestoreProtocol = FirebaseFirestoreService()) {
         self.auth = auth
@@ -28,28 +32,35 @@ class SetsLogViewModel: ObservableObject {
         self.userId = auth.currentUser
     }
     
-    
+    // Logic to add a set
     func addSet(repsInput: String, weightInput: String){
+        // Makes sure set is valid
         guard validate(input: repsInput) && validate(input: weightInput) else {
             return
         }
-         
+        // Makes sure input is integers
         guard let reps = Int(repsInput), let weight = Int(weightInput) else {
             return
         }
-        
+        // Calls firestore to add set
         firestore.insertSet(userId: self.userId, workout: self.workout, excercise: self.excercise, reps: Int(reps), weight: Int(weight)) { [weak self] result in
             guard self != nil else {
                 return
             }
             
+            // Error handling
             if case let .failure(error) = result {
                 self?.errorMessage = error.localizedDescription
+            } else {
+                self?.errorMessage = ""
             }
         }
-        fetchSets()
+        if firstFetch {
+            fetchSets()
+        }
     }
     
+    // Calls firestore api to delete set
     func deleteSet() {
         guard let toDelete = toDelete else {
             return
@@ -66,8 +77,12 @@ class SetsLogViewModel: ObservableObject {
                 self?.toDelete = nil
             }
         }
+        if firstFetch {
+            fetchSets()
+        }
     }
     
+    // Calls firestore api to fetch sets
     func fetchSets() {
         firestore.fetchSets(userId: self.userId, workout: self.workout, excercise: self.excercise) { [weak self] result in
             switch result {
@@ -79,6 +94,7 @@ class SetsLogViewModel: ObservableObject {
         }
     }
     
+    // Validates input, sets error message if invalid
     private func validate(input: String) -> Bool {
         guard input.rangeOfCharacter(from: CharacterSet.letters.inverted) != nil else {
             self.errorMessage = "Only numeric characters allowewd."

--- a/Sweat Social/ViewModels/SetsLogViewModel.swift
+++ b/Sweat Social/ViewModels/SetsLogViewModel.swift
@@ -37,6 +37,7 @@ class SetsLogViewModel: ObservableObject {
                     print(error.localizedDescription)
             }
         }
+        fetchSets()
     }
     
     func fetchSets() {

--- a/Sweat Social/ViewModels/WorkoutLogViewModel.swift
+++ b/Sweat Social/ViewModels/WorkoutLogViewModel.swift
@@ -69,6 +69,17 @@ class WorkoutLogViewModel: ObservableObject {
         }
     }
     
+    func deleteWorkout(toDelete: WorkoutExcercise) {
+        firestore.deleteWorkout(userId: self.userId, workoutToDelete: toDelete, exerciseToDelete: nil) { [weak self] result in
+            switch result {
+            case .failure(let error):
+                print(error.localizedDescription)
+            default:
+                return
+            }
+        }
+    }
+    
     private func validate(input: String) -> Bool {
 
         guard input.count >= 3 && input.count <= 20 else {

--- a/Sweat Social/ViewModels/WorkoutLogViewModel.swift
+++ b/Sweat Social/ViewModels/WorkoutLogViewModel.swift
@@ -16,29 +16,23 @@ class WorkoutLogViewModel: ObservableObject {
     
     private let firestore: FirestoreProtocol
     private let auth: AuthProtocol
-    private let workout: String?
+    //private let workout: String?
     
-    init(workout: String?,auth: AuthProtocol = FirebaseAuthService(),
+    init(auth: AuthProtocol = FirebaseAuthService(),
          firestore: FirestoreProtocol = FirebaseFirestoreService()) {
         self.auth = auth
         self.firestore = firestore
-        self.workout = workout
+        //self.workout = workout
         self.userId = auth.currentUser
-        fetchWorkouts(userId: userId,workout: workout)
     }
     
     
-    func addWorkout(workoutName: String,excerciseName:String? = nil){
+    func addWorkout(workoutName: String){
         let dateAdded = Date().timeIntervalSince1970
         
         let newWorkout = WorkoutExcercise(id: workoutName, dateAdded: dateAdded)
-        var newExcercise: WorkoutExcercise? = nil
         
-        if let excerciseName = excerciseName {
-            newExcercise = WorkoutExcercise(id: excerciseName, dateAdded: dateAdded)
-        }
-        
-        firestore.insertWorkout(userId: self.userId, newWorkoutCategory: newWorkout, newExcercise: newExcercise) { [weak self] result in
+        firestore.insertWorkout(userId: self.userId, newWorkoutCategory: newWorkout, newExcercise: nil) { [weak self] result in
             guard self != nil else { return }
             
             if case let .failure(error) = result {
@@ -51,9 +45,9 @@ class WorkoutLogViewModel: ObservableObject {
         }
     }
     
-    func fetchWorkouts(userId: String, workout: String? = nil) {
+    func fetchWorkouts() {
         
-        firestore.fetchWorkouts(userId: userId, workout: workout) { [weak self] result in
+        firestore.fetchWorkouts(userId: self.userId, workout: nil) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)

--- a/Sweat Social/ViewModels/WorkoutLogViewModel.swift
+++ b/Sweat Social/ViewModels/WorkoutLogViewModel.swift
@@ -13,6 +13,7 @@ class WorkoutLogViewModel: ObservableObject {
     @Published var userId: String
     @Published var addWorkoutForm = false
     @Published var workoutList: [WorkoutExcercise] = []
+    @Published var errorMessage = ""
     
     private let firestore: FirestoreProtocol
     private let auth: AuthProtocol
@@ -27,7 +28,11 @@ class WorkoutLogViewModel: ObservableObject {
     }
     
     
-    func addWorkout(workoutName: String){
+    func addWorkout(workoutName: String) {
+        guard validate(input: workoutName) else {
+            return
+        }
+        
         let dateAdded = Date().timeIntervalSince1970
         
         let newWorkout = WorkoutExcercise(id: workoutName, dateAdded: dateAdded)
@@ -37,12 +42,18 @@ class WorkoutLogViewModel: ObservableObject {
             
             if case let .failure(error) = result {
                 if error is WorkoutExists {
-                    print("This workout already exists")
+                    self?.errorMessage = "This workout already exists."
+                    return
                 } else {
-                    print(error.localizedDescription)
+                    self?.errorMessage = error.localizedDescription
+                    return
                 }
+            } else {
+                self?.errorMessage = ""
             }
         }
+        //self.errorMessage = ""
+        
     }
     
     func fetchWorkouts() {
@@ -56,6 +67,25 @@ class WorkoutLogViewModel: ObservableObject {
             }
             
         }
+    }
+    
+    private func validate(input: String) -> Bool {
+
+        guard input.count >= 3 && input.count <= 20 else {
+            self.errorMessage = "Input must be between 3 and 20 characters."
+            return false
+            
+        }
+        
+        let allowedCharacterSet = CharacterSet.letters.union(.whitespaces)
+        guard input.rangeOfCharacter(from: allowedCharacterSet.inverted) == nil else {
+            self.errorMessage = "Invalid characters in input."
+            return false
+        }
+
+        
+        return true
+        
     }
     
     

--- a/Sweat Social/ViewModels/WorkoutLogViewModel.swift
+++ b/Sweat Social/ViewModels/WorkoutLogViewModel.swift
@@ -14,6 +14,8 @@ class WorkoutLogViewModel: ObservableObject {
     @Published var addWorkoutForm = false
     @Published var workoutList: [WorkoutExcercise] = []
     @Published var errorMessage = ""
+    @Published var toDelete: WorkoutExcercise? = nil
+    @Published var deleteSuccess = false
     
     private let firestore: FirestoreProtocol
     private let auth: AuthProtocol
@@ -69,12 +71,17 @@ class WorkoutLogViewModel: ObservableObject {
         }
     }
     
-    func deleteWorkout(toDelete: WorkoutExcercise) {
+    func deleteWorkout() {
+        guard let toDelete = toDelete else {
+            return
+        }
+        
         firestore.deleteWorkout(userId: self.userId, workoutToDelete: toDelete, exerciseToDelete: nil) { [weak self] result in
             switch result {
             case .failure(let error):
                 print(error.localizedDescription)
             default:
+                self?.toDelete = nil
                 return
             }
         }
@@ -82,8 +89,8 @@ class WorkoutLogViewModel: ObservableObject {
     
     private func validate(input: String) -> Bool {
 
-        guard input.count >= 3 && input.count <= 20 else {
-            self.errorMessage = "Input must be between 3 and 20 characters."
+        guard input.count >= 3 && input.count <= 30 else {
+            self.errorMessage = "Input must be between 3 and 30 characters."
             return false
             
         }

--- a/Sweat Social/ViewModels/WorkoutLogViewModel.swift
+++ b/Sweat Social/ViewModels/WorkoutLogViewModel.swift
@@ -9,27 +9,27 @@ import Foundation
 import FirebaseAuth
 import FirebaseFirestore
 
+// View model for workout log view
 class WorkoutLogViewModel: ObservableObject {
     @Published var userId: String
-    @Published var addWorkoutForm = false
-    @Published var workoutList: [WorkoutExcercise] = []
+    @Published var addWorkoutForm = false // Controls add workout popup
+    @Published var workoutList: [WorkoutExcercise] = [] // List of workouts
     @Published var errorMessage = ""
-    @Published var toDelete: WorkoutExcercise? = nil
-    @Published var deleteSuccess = false
+    @Published var toDelete: WorkoutExcercise? = nil // Workout pending deletion, also controls popup
+    @Published var deleteSuccess = false // Helps control deletion confirm popup
     
     private let firestore: FirestoreProtocol
     private let auth: AuthProtocol
-    //private let workout: String?
     
+    // Iniitalize firestore and auth
     init(auth: AuthProtocol = FirebaseAuthService(),
          firestore: FirestoreProtocol = FirebaseFirestoreService()) {
         self.auth = auth
         self.firestore = firestore
-        //self.workout = workout
         self.userId = auth.currentUser
     }
     
-    
+    // Add workout
     func addWorkout(workoutName: String) {
         guard validate(input: workoutName) else {
             return
@@ -54,7 +54,6 @@ class WorkoutLogViewModel: ObservableObject {
                 self?.errorMessage = ""
             }
         }
-        //self.errorMessage = ""
         
     }
     

--- a/Sweat Social/ViewModels/WorkoutViewManagerViewModel.swift
+++ b/Sweat Social/ViewModels/WorkoutViewManagerViewModel.swift
@@ -14,6 +14,8 @@ class WorkoutViewManagerViewModel: ObservableObject {
     
     @Published var dismiss = false
     @Published var excerciseDismiss = true
+    @Published var errorMessage = ""
     
     init() {}
+    
 }

--- a/Sweat Social/ViewModels/WorkoutViewManagerViewModel.swift
+++ b/Sweat Social/ViewModels/WorkoutViewManagerViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  WorkoutViewManagerViewModel.swift
+//  Sweat Social
+//
+//  Created by Jack.Knox on 2024-03-25.
+//
+
+import Foundation
+
+class WorkoutViewManagerViewModel: ObservableObject {
+    @Published var addForm = false
+    @Published var title = "Your Workout"
+    @Published var backButton = false
+    
+    @Published var dismiss = false
+    @Published var excerciseDismiss = true
+    
+    init() {}
+}

--- a/Sweat Social/ViewModels/WorkoutViewManagerViewModel.swift
+++ b/Sweat Social/ViewModels/WorkoutViewManagerViewModel.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+// Variables used largely to control the header, and its associated buttons: Add and back
+// No functions currently
 class WorkoutViewManagerViewModel: ObservableObject {
     @Published var addForm = false
     @Published var title = "Your Workout"

--- a/Sweat Social/Views/ExcerciseLogView.swift
+++ b/Sweat Social/Views/ExcerciseLogView.swift
@@ -16,7 +16,7 @@ struct ExcerciseLogView: View {
         NavigationStack {
             ZStack {
                 VStack {
-                    WorkoutHeaderView(showAddWorkoutForm: $viewModel.addExcerciseForm, title: workout.id)
+                    WorkoutHeaderView(showAddWorkoutForm: $viewModel.addExcerciseForm, title: workout.id, backButton: true)
                     
                     ScrollView {
                         LazyVGrid(columns: [GridItem(.flexible(), spacing: 5), GridItem(.flexible(), spacing: 5)], spacing: 5) {

--- a/Sweat Social/Views/ExcerciseLogView.swift
+++ b/Sweat Social/Views/ExcerciseLogView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+// Excercise log view, displays excercises for a certain workout and gives a preview of its sets
 struct ExcerciseLogView: View {
     let workout: WorkoutExcercise
     @Environment(\.presentationMode) var
@@ -21,6 +22,7 @@ struct ExcerciseLogView: View {
         NavigationStack {
             ZStack {
                 ScrollView {
+                    // Displays the excercise buttons in two columns.
                     LazyVGrid(columns: [GridItem(.flexible(), spacing: 5), GridItem(.flexible(), spacing: 5)], spacing: 5) {
                         ForEach(viewModel.excerciseList) { excercise in
                             ExcerciseButtonView(workout: workout.id, 
@@ -32,7 +34,7 @@ struct ExcerciseLogView: View {
                         
                     }
                 }
-                
+                // Display add excercise form if button is clicked
                 if viewManagerViewModel.addForm {
                     ZStack {
                         AddWorkoutView(showAddWorkoutForm: $viewManagerViewModel.addForm,
@@ -44,24 +46,26 @@ struct ExcerciseLogView: View {
                     }
                 }
                 
+                // If excercise is held, displays delete confirmation form
                 if let toDelete = viewModel.toDelete {
                     DeleteConfirmationView(toDelete: toDelete.id,
                                            toDeleteType: "excercise",
                                            update: $viewModel.deleteSuccess,
                                            delete: viewModel.deleteExcercise)
                     .onChange(of: viewModel.deleteSuccess) { _ in
-                        viewModel.toDelete = nil
+                        viewModel.toDelete = nil // On cancel, dismiss screen
                     }
                     
                 }
             }
-            .onAppear {
+            .onAppear { // Initialize values and excercises
                 viewModel.workout = workout
                 viewManagerViewModel.backButton = true
                 viewManagerViewModel.title = workout.id
                 viewModel.fetchExcercises()
             }
         }
+        // This triggers if back button is pressed. Excercise dismiss is additional logic to ensure that if the set view is dismissed, it displays excercise view, and not workout view.
         .onChange(of: viewManagerViewModel.dismiss) { _ in
             if(viewManagerViewModel.excerciseDismiss) {
                 viewManagerViewModel.title = "Your Workout"

--- a/Sweat Social/Views/ExcerciseLogView.swift
+++ b/Sweat Social/Views/ExcerciseLogView.swift
@@ -32,6 +32,8 @@ struct ExcerciseLogView: View {
                 if viewManagerViewModel.addForm {
                     ZStack {
                         AddWorkoutView(showAddWorkoutForm: $viewManagerViewModel.addForm,
+                                       errorMessage: $viewModel.errorMessage,
+                                       workoutList: $viewModel.excerciseList,
                                        mainTitle: "Add Excercise",
                                        placeHolder: "Enter Excercise",
                                        action: viewModel.addExcercise)

--- a/Sweat Social/Views/ExcerciseLogView.swift
+++ b/Sweat Social/Views/ExcerciseLogView.swift
@@ -15,15 +15,12 @@ struct ExcerciseLogView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                VStack {
-                    WorkoutHeaderView(showAddWorkoutForm: $viewModel.addExcerciseForm, title: workout.id, backButton: true)
-                    
-                    ScrollView {
-                        LazyVGrid(columns: [GridItem(.flexible(), spacing: 5), GridItem(.flexible(), spacing: 5)], spacing: 5) {
-                            ForEach(viewModel.excerciseList) { excercise in
-                                ExcerciseButtonView(workout: workout.id, excercise: excercise.id, action: viewModel.fetchSets)
-                            }
+                ScrollView {
+                    LazyVGrid(columns: [GridItem(.flexible(), spacing: 5), GridItem(.flexible(), spacing: 5)], spacing: 5) {
+                        ForEach(viewModel.excerciseList) { excercise in
+                            ExcerciseButtonView(workout: workout.id, excercise: excercise.id, action: viewModel.fetchSets)
                         }
+                       
                     }
                 }
                 
@@ -41,6 +38,7 @@ struct ExcerciseLogView: View {
                 viewModel.fetchExcercises()
             }
         }
+        .navigationBarHidden(true)
     }
 }
 

--- a/Sweat Social/Views/ExcerciseLogView.swift
+++ b/Sweat Social/Views/ExcerciseLogView.swift
@@ -1,0 +1,49 @@
+//
+//  ExcerciseLogView.swift
+//  Sweat Social
+//
+//  Created by Jack.Knox on 2024-03-23.
+//
+
+import SwiftUI
+
+struct ExcerciseLogView: View {
+    let workout: WorkoutExcercise
+    
+    @StateObject var viewModel = ExcerciseLogViewModel()
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                VStack {
+                    WorkoutHeaderView(showAddWorkoutForm: $viewModel.addExcerciseForm, title: workout.id)
+                    
+                    ScrollView {
+                        LazyVGrid(columns: [GridItem(.flexible(), spacing: 5), GridItem(.flexible(), spacing: 5)], spacing: 5) {
+                            ForEach(viewModel.excerciseList) { excercise in
+                                ExcerciseButtonView(workout: workout.id, excercise: excercise.id, action: viewModel.fetchSets)
+                            }
+                        }
+                    }
+                }
+                
+                if viewModel.addExcerciseForm {
+                    ZStack {
+                        AddWorkoutView(showAddWorkoutForm: $viewModel.addExcerciseForm,
+                                       mainTitle: "Add Excercise",
+                                       placeHolder: "Enter Excercise",
+                                       action: viewModel.addExcercise)
+                    }
+                }
+            }
+            .onAppear {
+                viewModel.workout = workout
+                viewModel.fetchExcercises()
+            }
+        }
+    }
+}
+
+#Preview {
+    ExcerciseLogView(workout: WorkoutExcercise(id: "Arms", dateAdded: 3600))
+}

--- a/Sweat Social/Views/ExcerciseLogView.swift
+++ b/Sweat Social/Views/ExcerciseLogView.swift
@@ -9,8 +9,13 @@ import SwiftUI
 
 struct ExcerciseLogView: View {
     let workout: WorkoutExcercise
+    @Environment(\.presentationMode) var
+        presentationMode: Binding<PresentationMode>
+    
+    @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
     
     @StateObject var viewModel = ExcerciseLogViewModel()
+    @State private var setDismiss = false
     
     var body: some View {
         NavigationStack {
@@ -18,15 +23,15 @@ struct ExcerciseLogView: View {
                 ScrollView {
                     LazyVGrid(columns: [GridItem(.flexible(), spacing: 5), GridItem(.flexible(), spacing: 5)], spacing: 5) {
                         ForEach(viewModel.excerciseList) { excercise in
-                            ExcerciseButtonView(workout: workout.id, excercise: excercise.id, action: viewModel.fetchSets)
+                            ExcerciseButtonView(workout: workout.id, excercise: excercise.id, viewManagerViewModel: viewManagerViewModel, action: viewModel.fetchSets)
                         }
-                       
+                        
                     }
                 }
                 
-                if viewModel.addExcerciseForm {
+                if viewManagerViewModel.addForm {
                     ZStack {
-                        AddWorkoutView(showAddWorkoutForm: $viewModel.addExcerciseForm,
+                        AddWorkoutView(showAddWorkoutForm: $viewManagerViewModel.addForm,
                                        mainTitle: "Add Excercise",
                                        placeHolder: "Enter Excercise",
                                        action: viewModel.addExcercise)
@@ -35,7 +40,19 @@ struct ExcerciseLogView: View {
             }
             .onAppear {
                 viewModel.workout = workout
+                viewManagerViewModel.backButton = true
+                viewManagerViewModel.title = workout.id
                 viewModel.fetchExcercises()
+            }
+        }
+        .onChange(of: viewManagerViewModel.dismiss) { _ in
+            if(viewManagerViewModel.excerciseDismiss) {
+                viewManagerViewModel.title = "Your Workout"
+                viewManagerViewModel.backButton = false
+                presentationMode.wrappedValue
+                    .dismiss()
+            } else {
+                viewManagerViewModel.excerciseDismiss.toggle()
             }
         }
         .navigationBarHidden(true)
@@ -43,5 +60,5 @@ struct ExcerciseLogView: View {
 }
 
 #Preview {
-    ExcerciseLogView(workout: WorkoutExcercise(id: "Arms", dateAdded: 3600))
+    ExcerciseLogView(workout: WorkoutExcercise(id: "Arms", dateAdded: 3600), viewManagerViewModel: WorkoutViewManagerViewModel())
 }

--- a/Sweat Social/Views/ExcerciseLogView.swift
+++ b/Sweat Social/Views/ExcerciseLogView.swift
@@ -23,7 +23,11 @@ struct ExcerciseLogView: View {
                 ScrollView {
                     LazyVGrid(columns: [GridItem(.flexible(), spacing: 5), GridItem(.flexible(), spacing: 5)], spacing: 5) {
                         ForEach(viewModel.excerciseList) { excercise in
-                            ExcerciseButtonView(workout: workout.id, excercise: excercise.id, viewManagerViewModel: viewManagerViewModel, action: viewModel.fetchSets)
+                            ExcerciseButtonView(workout: workout.id, 
+                                                excercise: excercise,
+                                                toDelete: $viewModel.toDelete,
+                                                viewManagerViewModel: viewManagerViewModel,
+                                                action: viewModel.fetchSets)
                         }
                         
                     }
@@ -38,6 +42,17 @@ struct ExcerciseLogView: View {
                                        placeHolder: "Enter Excercise",
                                        action: viewModel.addExcercise)
                     }
+                }
+                
+                if let toDelete = viewModel.toDelete {
+                    DeleteConfirmationView(toDelete: toDelete.id,
+                                           toDeleteType: "excercise",
+                                           update: $viewModel.deleteSuccess,
+                                           delete: viewModel.deleteExcercise)
+                    .onChange(of: viewModel.deleteSuccess) { _ in
+                        viewModel.toDelete = nil
+                    }
+                    
                 }
             }
             .onAppear {

--- a/Sweat Social/Views/SetsLogView.swift
+++ b/Sweat Social/Views/SetsLogView.swift
@@ -33,7 +33,10 @@ struct SetsLogView: View {
                 
                 if viewManagerViewModel.addForm {
                     ZStack {
-                        AddSetView(showAddSetForm: $viewManagerViewModel.addForm, action: viewModel.addSet)
+                        AddSetView(showAddSetForm: $viewManagerViewModel.addForm,
+                                   errorMessage: $viewModel.errorMessage,
+                                   setList: $viewModel.sets,
+                                   action: viewModel.addSet)
                     }
                 }
                 

--- a/Sweat Social/Views/SetsLogView.swift
+++ b/Sweat Social/Views/SetsLogView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SetsLogView: View {
     let workout: String
     let excercise: String
-    
+    let sets: Sets?
     
     @StateObject var viewModel = SetsLogViewModel()
     
@@ -42,7 +42,7 @@ struct SetsLogView: View {
                 .onAppear {
                     viewModel.workout = workout
                     viewModel.excercise = excercise
-                    viewModel.fetchSets()
+                    viewModel.sets = sets
                 }
             }
             .padding(.top,40)
@@ -55,5 +55,5 @@ struct SetsLogView: View {
 
 
 #Preview {
-    SetsLogView(workout: "Arms", excercise: "Curl")
+    SetsLogView(workout: "Arms", excercise: "Curl", sets: nil)
 }

--- a/Sweat Social/Views/SetsLogView.swift
+++ b/Sweat Social/Views/SetsLogView.swift
@@ -20,7 +20,7 @@ struct SetsLogView: View {
             VStack {
                 ZStack {
                     VStack {
-                        WorkoutHeaderView(showAddWorkoutForm: $viewModel.addSetForm, title: "Sets")
+                        WorkoutHeaderView(showAddWorkoutForm: $viewModel.addSetForm, title: "Sets", backButton: true)
                         
                         ScrollView {
                             if let sets = viewModel.sets {

--- a/Sweat Social/Views/SetsLogView.swift
+++ b/Sweat Social/Views/SetsLogView.swift
@@ -25,9 +25,13 @@ struct SetsLogView: View {
                 ScrollView {
                     if let sets = viewModel.sets {
                         
-                        ForEach(0..<sets.reps.count, id: \.self) { index in
-                            SetButtonView(reps: sets.reps[index], weight: sets.weight[index], setNum: index+1)
+                        ForEach(0..<sets.weight.count, id: \.self) { index in
+                            SetButtonView(reps: sets.reps[index],
+                                          weight: sets.weight[index],
+                                          setNum: index+1,
+                                          toDelete: $viewModel.toDelete)
                         }
+                        
                     }
                 }
                 
@@ -40,6 +44,15 @@ struct SetsLogView: View {
                     }
                 }
                 
+                if let toDelete = viewModel.toDelete {
+                    DeleteConfirmationView(toDelete: String(toDelete+1),
+                                           toDeleteType: "Set", update: $viewModel.deleteSuccess,
+                                           delete: viewModel.deleteSet)
+                    .onChange(of: viewModel.deleteSuccess) { _ in
+                        viewModel.toDelete = nil
+                    }
+                }
+                
             }
             .onAppear {
                 viewModel.workout = workout
@@ -49,6 +62,7 @@ struct SetsLogView: View {
                 viewManagerViewModel.backButton = true
                 viewManagerViewModel.excerciseDismiss = false
                 viewModel.sets = sets
+                
             }
             .onChange(of: viewManagerViewModel.dismiss) { _ in
                 presentationMode.wrappedValue

--- a/Sweat Social/Views/SetsLogView.swift
+++ b/Sweat Social/Views/SetsLogView.swift
@@ -16,41 +16,31 @@ struct SetsLogView: View {
     
     
     var body: some View {
-        NavigationStack {
-            VStack {
-                ZStack {
-                    VStack {
-                        WorkoutHeaderView(showAddWorkoutForm: $viewModel.addSetForm, title: "Sets", backButton: true)
-                        
-                        ScrollView {
-                            if let sets = viewModel.sets {
-                                
-                                ForEach(0..<sets.reps.count, id: \.self) { index in
-                                    SetButtonView(reps: sets.reps[index], weight: sets.weight[index], setNum: index+1)
-                                }
-                            }
-                        }
-                    }
-
-                    if viewModel.addSetForm {
-                        ZStack {
-                            AddSetView(showAddSetForm: $viewModel.addSetForm, action: viewModel.addSet) 
-                        }
-                    }
+        ZStack {
+            ScrollView {
+                if let sets = viewModel.sets {
                     
-                }
-                .onAppear {
-                    viewModel.workout = workout
-                    viewModel.excercise = excercise
-                    viewModel.sets = sets
+                    ForEach(0..<sets.reps.count, id: \.self) { index in
+                        SetButtonView(reps: sets.reps[index], weight: sets.weight[index], setNum: index+1)
+                    }
                 }
             }
-            .padding(.top,40)
+
+            if viewModel.addSetForm {
+                ZStack {
+                    AddSetView(showAddSetForm: $viewModel.addSetForm, action: viewModel.addSet)
+                }
+            }
+            
+        }
+        .onAppear {
+            viewModel.workout = workout
+            viewModel.excercise = excercise
+            viewModel.sets = sets
         }
         .navigationBarHidden(true)
-        
-        
     }
+        
 }
 
 

--- a/Sweat Social/Views/SetsLogView.swift
+++ b/Sweat Social/Views/SetsLogView.swift
@@ -12,38 +12,53 @@ struct SetsLogView: View {
     let excercise: String
     let sets: Sets?
     
+    @Environment(\.presentationMode) var
+        presentationMode: Binding<PresentationMode>
+    @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
+    
     @StateObject var viewModel = SetsLogViewModel()
     
     
     var body: some View {
-        ZStack {
-            ScrollView {
-                if let sets = viewModel.sets {
-                    
-                    ForEach(0..<sets.reps.count, id: \.self) { index in
-                        SetButtonView(reps: sets.reps[index], weight: sets.weight[index], setNum: index+1)
+        NavigationStack {
+            ZStack {
+                ScrollView {
+                    if let sets = viewModel.sets {
+                        
+                        ForEach(0..<sets.reps.count, id: \.self) { index in
+                            SetButtonView(reps: sets.reps[index], weight: sets.weight[index], setNum: index+1)
+                        }
                     }
                 }
-            }
-
-            if viewModel.addSetForm {
-                ZStack {
-                    AddSetView(showAddSetForm: $viewModel.addSetForm, action: viewModel.addSet)
+                
+                if viewManagerViewModel.addForm {
+                    ZStack {
+                        AddSetView(showAddSetForm: $viewManagerViewModel.addForm, action: viewModel.addSet)
+                    }
                 }
+                
             }
-            
-        }
-        .onAppear {
-            viewModel.workout = workout
-            viewModel.excercise = excercise
-            viewModel.sets = sets
+            .onAppear {
+                viewModel.workout = workout
+                viewModel.excercise = excercise
+                viewManagerViewModel.title = excercise
+                
+                viewManagerViewModel.backButton = true
+                viewManagerViewModel.excerciseDismiss = false
+                viewModel.sets = sets
+            }
+            .onChange(of: viewManagerViewModel.dismiss) { _ in
+                presentationMode.wrappedValue
+                    .dismiss()
+            }
         }
         .navigationBarHidden(true)
+        
     }
         
 }
 
 
 #Preview {
-    SetsLogView(workout: "Arms", excercise: "Curl", sets: nil)
+    SetsLogView(workout: "Arms", excercise: "Curl", sets: nil, viewManagerViewModel: WorkoutViewManagerViewModel())
 }

--- a/Sweat Social/Views/SetsLogView.swift
+++ b/Sweat Social/Views/SetsLogView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+// View to display the sets for an excercise
 struct SetsLogView: View {
     let workout: String
     let excercise: String
@@ -22,9 +23,10 @@ struct SetsLogView: View {
     var body: some View {
         NavigationStack {
             ZStack {
+                // Scroll view to display sets if they exist
                 ScrollView {
                     if let sets = viewModel.sets {
-                        
+                        // Sets are stored as two lists, one of weight and one of reps. Grab the ith index of each and display it
                         ForEach(0..<sets.weight.count, id: \.self) { index in
                             SetButtonView(reps: sets.reps[index],
                                           weight: sets.weight[index],
@@ -35,6 +37,7 @@ struct SetsLogView: View {
                     }
                 }
                 
+                // Display add set popup if add button pressed
                 if viewManagerViewModel.addForm {
                     ZStack {
                         AddSetView(showAddSetForm: $viewManagerViewModel.addForm,
@@ -44,6 +47,7 @@ struct SetsLogView: View {
                     }
                 }
                 
+                //Display delete confirmation popup if a set is held
                 if let toDelete = viewModel.toDelete {
                     DeleteConfirmationView(toDelete: String(toDelete+1),
                                            toDeleteType: "Set", update: $viewModel.deleteSuccess,
@@ -64,6 +68,7 @@ struct SetsLogView: View {
                 viewModel.sets = sets
                 
             }
+            // Back button logic
             .onChange(of: viewManagerViewModel.dismiss) { _ in
                 presentationMode.wrappedValue
                     .dismiss()

--- a/Sweat Social/Views/TabBarView.swift
+++ b/Sweat Social/Views/TabBarView.swift
@@ -29,6 +29,7 @@ struct TabBar: View {
                     .tabItem {
                         Label("Log Workout", systemImage: "plus.circle.fill")
                     }
+                    
                 
                 GoalsView()
                     .tabItem {

--- a/Sweat Social/Views/TabBarView.swift
+++ b/Sweat Social/Views/TabBarView.swift
@@ -25,7 +25,7 @@ struct TabBar: View {
                     }
                 
                 
-                WorkoutLogView()
+                WorkoutViewManagerView()
                     .tabItem {
                         Label("Log Workout", systemImage: "plus.circle.fill")
                     }

--- a/Sweat Social/Views/TabBarView.swift
+++ b/Sweat Social/Views/TabBarView.swift
@@ -25,11 +25,7 @@ struct TabBar: View {
                     }
                 
                 
-                WorkoutLogView(title: "Your Workout",
-                               workoutSelected: nil,
-                               addMainTitle:"Add Workout Category",
-                               addPlaceHolder: "Enter workout category",
-                               excercisesListed: false)
+                WorkoutLogView()
                     .tabItem {
                         Label("Log Workout", systemImage: "plus.circle.fill")
                     }

--- a/Sweat Social/Views/WorkoutHelperViews/AddSetView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/AddSetView.swift
@@ -11,8 +11,10 @@ struct AddSetView: View {
     @State private var inputWeight = ""
     @State private var inputReps = ""
     @Binding var showAddSetForm: Bool
+    @Binding var errorMessage: String
+    @Binding var setList: Sets?
     
-    let action: (Int, Int) -> Void
+    let action: (String, String) -> Void
     
     
     var body: some View {
@@ -40,40 +42,52 @@ struct AddSetView: View {
                     .font(.system(size:26))
                     .foregroundStyle(.white)
                     .bold()
-                    .offset(y:-5)
-                 
-                HStack {
-                    Text("Weight: ")
-                        .font(.system(size:22))
-                        .offset(x:50)
-                    
-                    TextField("Weight", text: $inputWeight)
-                        .offset(x:100)
-                        .font(.system(size:22))
-                        .padding()
-                }
-                .offset(y:10)
+                    .offset(y:-45)
                 
-                HStack {
-                    Text("Reps: ")
-                        .font(.system(size:22))
-                        .offset(x:50)
+                ZStack {
+                    if errorMessage != "" {
+                        Text(errorMessage)
+                            .frame(width:320)
+                            .font(.system(size:18))
+                            .multilineTextAlignment(.center)
+                            .offset(y:-25)
+                    }
                     
-                    TextField("Reps", text: $inputReps)
-                        .offset(x:120)
-                        .font(.system(size:22))
-                        .padding()
-                        .onSubmit {
-                            if !inputWeight.isEmpty && !inputReps.isEmpty {
-                                if let intWeight = Int(inputWeight), let intReps = Int(inputReps) {
-                                    action(intWeight,intReps)
+                    HStack {
+                        Text("Weight: ")
+                            .font(.system(size:22))
+                            .offset(x:50)
+                        
+                        TextField("Weight", text: $inputWeight)
+                            .offset(x:100)
+                            .font(.system(size:22))
+                            .padding()
+                    }
+                    .offset(y:10)
+                    
+                    
+                    HStack {
+                        Text("Reps: ")
+                            .font(.system(size:22))
+                            .offset(x:50)
+                        
+                        TextField("Reps", text: $inputReps)
+                            .offset(x:120)
+                            .font(.system(size:22))
+                            .padding()
+                            .onSubmit {
+                                if !inputWeight.isEmpty && !inputReps.isEmpty {
+                                        action(inputWeight,inputReps)
+                                    
                                 }
-                                
                             }
-                            showAddSetForm.toggle()
-                        }
+                            .onChange(of: setList?.reps.count) { _ in
+                                    showAddSetForm.toggle()
+                            }
+                    }
+                    .offset(y: 50)
                 }
-                
+                    
             }
             
       
@@ -83,7 +97,7 @@ struct AddSetView: View {
 }
 
 #Preview {
-    AddSetView(showAddSetForm: .constant(true)){_,_ in
+    AddSetView(showAddSetForm: .constant(true), errorMessage: .constant(""), setList: .constant(nil)){_,_ in
         
     }
 }

--- a/Sweat Social/Views/WorkoutHelperViews/AddSetView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/AddSetView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+// Similar to add workout view, but multiple fields when adding a set
 struct AddSetView: View {
     @State private var inputWeight = ""
     @State private var inputReps = ""
@@ -45,6 +46,7 @@ struct AddSetView: View {
                     .offset(y:-45)
                 
                 ZStack {
+                    // Perform input validation, display error message on failure
                     if errorMessage != "" {
                         Text(errorMessage)
                             .frame(width:320)
@@ -76,13 +78,16 @@ struct AddSetView: View {
                             .font(.system(size:22))
                             .padding()
                             .onSubmit {
+                                // Only submittable if input weight and input reps are not empty
                                 if !inputWeight.isEmpty && !inputReps.isEmpty {
-                                        action(inputWeight,inputReps)
+                                        action(inputReps,inputWeight)
                                     
+                                } else {
+                                    errorMessage = "Please fill in both fields."
                                 }
                             }
                             .onChange(of: setList?.reps.count) { _ in
-                                    showAddSetForm.toggle()
+                                    showAddSetForm.toggle() // dismiss popup on succesful add
                             }
                     }
                     .offset(y: 50)

--- a/Sweat Social/Views/WorkoutHelperViews/AddWorkoutView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/AddWorkoutView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+// Popup view for excercise and workout screen. Takes input  variables to differentiate
 struct AddWorkoutView: View {
     @State private var input = ""
     @Binding var showAddWorkoutForm: Bool
@@ -39,12 +40,15 @@ struct AddWorkoutView: View {
             }
 
             VStack {
+                
+                // Variable title, based on workout or excercise view
                 Text(mainTitle)
                     .font(.system(size:26))
                     .foregroundStyle(.white)
                     .bold()
                     .offset(y:-40)
                 
+                // Perform validation and display error message if it exists
                 ZStack {
                     if errorMessage != "" && errorMessage != "nil"{
                         Text(errorMessage)
@@ -68,10 +72,10 @@ struct AddWorkoutView: View {
                             .lineLimit(nil)
                             .padding()
                             .onSubmit {
-                                action(input)
+                                action(input) // Triggers add workout, passed in from viewmodel
                             }
                             .onChange(of: workoutList.count) { _ in
-                                showAddWorkoutForm.toggle()
+                                showAddWorkoutForm.toggle() // Remove popup
                             }
                     }
                     

--- a/Sweat Social/Views/WorkoutHelperViews/AddWorkoutView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/AddWorkoutView.swift
@@ -10,10 +10,10 @@ import SwiftUI
 struct AddWorkoutView: View {
     @State private var input = ""
     @Binding var showAddWorkoutForm: Bool
-    let workoutSelected: String?
+    //let workoutSelected: String?
     let mainTitle: String
     let placeHolder: String
-    let action: (String, String?) -> Void
+    let action: (String) -> Void
     
     
     var body: some View {
@@ -53,11 +53,7 @@ struct AddWorkoutView: View {
                         .font(.system(size:22))
                         .padding()
                         .onSubmit {
-                            if let workoutSelected = workoutSelected {
-                                action(workoutSelected,input)
-                            } else {
-                                action(input,nil)
-                            }
+                            action(input)
                             showAddWorkoutForm.toggle()
                         }
                 }
@@ -72,7 +68,7 @@ struct AddWorkoutView: View {
 
 
 #Preview {
-    AddWorkoutView(showAddWorkoutForm: .constant(true), workoutSelected: "", mainTitle: "Enter workout", placeHolder: "Add excercise") {_,_ in 
-        // Nothing
+    AddWorkoutView(showAddWorkoutForm: .constant(true), mainTitle: "Enter workout", placeHolder: "Add excercise") {_ in 
+        //Nothing
     }
 }

--- a/Sweat Social/Views/WorkoutHelperViews/AddWorkoutView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/AddWorkoutView.swift
@@ -58,11 +58,14 @@ struct AddWorkoutView: View {
                     HStack {
                         Text("Enter: ")
                             .font(.system(size:22))
-                            .offset(x:50)
+                            .offset(x:20)
                         
                         TextField(placeHolder, text: $input)
-                            .offset(x:100)
+                            .offset(x:30)
                             .font(.system(size:22))
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth:180)
+                            .lineLimit(nil)
                             .padding()
                             .onSubmit {
                                 action(input)
@@ -71,6 +74,7 @@ struct AddWorkoutView: View {
                                 showAddWorkoutForm.toggle()
                             }
                     }
+                    
                     .offset(y:25)
                 }
                 

--- a/Sweat Social/Views/WorkoutHelperViews/AddWorkoutView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/AddWorkoutView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct AddWorkoutView: View {
     @State private var input = ""
     @Binding var showAddWorkoutForm: Bool
+    @Binding var errorMessage: String
+    @Binding var workoutList: [WorkoutExcercise]
     //let workoutSelected: String?
     let mainTitle: String
     let placeHolder: String
@@ -43,19 +45,33 @@ struct AddWorkoutView: View {
                     .bold()
                     .offset(y:-40)
                 
-                HStack {
-                    Text("Enter: ")
-                        .font(.system(size:22))
-                        .offset(x:50)
+                ZStack {
+                    if errorMessage != "" && errorMessage != "nil"{
+                        Text(errorMessage)
+                            .frame(width:300)
+                            .font(.system(size:18))
+                            .multilineTextAlignment(.center)
+                            .offset(y:-20)
+                        
+                    }
                     
-                    TextField(placeHolder, text: $input)
-                        .offset(x:100)
-                        .font(.system(size:22))
-                        .padding()
-                        .onSubmit {
-                            action(input)
-                            showAddWorkoutForm.toggle()
-                        }
+                    HStack {
+                        Text("Enter: ")
+                            .font(.system(size:22))
+                            .offset(x:50)
+                        
+                        TextField(placeHolder, text: $input)
+                            .offset(x:100)
+                            .font(.system(size:22))
+                            .padding()
+                            .onSubmit {
+                                action(input)
+                            }
+                            .onChange(of: workoutList.count) { _ in
+                                showAddWorkoutForm.toggle()
+                            }
+                    }
+                    .offset(y:25)
                 }
                 
             }
@@ -68,7 +84,7 @@ struct AddWorkoutView: View {
 
 
 #Preview {
-    AddWorkoutView(showAddWorkoutForm: .constant(true), mainTitle: "Enter workout", placeHolder: "Add excercise") {_ in 
+    AddWorkoutView(showAddWorkoutForm: .constant(true), errorMessage: .constant(""), workoutList: .constant([]), mainTitle: "Enter workout", placeHolder: "Add excercise") {_ in
         //Nothing
     }
 }

--- a/Sweat Social/Views/WorkoutHelperViews/DeleteConfirmationView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/DeleteConfirmationView.swift
@@ -7,9 +7,10 @@
 
 import SwiftUI
 
+// Delete confirmations screen, used across all three views
 struct DeleteConfirmationView: View {
     let toDelete: String
-    let toDeleteType: String
+    let toDeleteType: String // Used to edit display message
     @Binding var update: Bool
     let delete: () -> Void
     
@@ -43,8 +44,9 @@ struct DeleteConfirmationView: View {
                     .multilineTextAlignment(.center)
                     .bold()
                     .frame(width:320)
-                    .offset(y:-40)
+                    .offset(y:-30)
                 
+                // Confirmation button, calles delete function passed in from viewModel
                 Button {
                     delete()
                 } label: {
@@ -59,6 +61,7 @@ struct DeleteConfirmationView: View {
                     .frame(width: 141, height: 45)
                 }
                 
+                // Cancel button, toggles update variable which dismisses the popup
                 Button {
                     update.toggle()
                 } label: {
@@ -75,7 +78,7 @@ struct DeleteConfirmationView: View {
             }
         }
         .onAppear {
-            message = (toDeleteType == "Set") ? "Are you sure you want to delete Set \(toDelete)?" : "Are you sure you want to delete the \(toDeleteType), \(toDelete)?"
+            message = (toDeleteType == "Set") ? "Are you sure you want to delete Set \(toDelete)?" : "Are you sure you want to delete the \(toDeleteType), \(toDelete)?" // Sets appropriate title
         }
         
     }

--- a/Sweat Social/Views/WorkoutHelperViews/DeleteConfirmationView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/DeleteConfirmationView.swift
@@ -1,0 +1,88 @@
+//
+//  DeleteConfirmationView.swift
+//  Sweat Social
+//
+//  Created by Jack.Knox on 2024-03-26.
+//
+
+import SwiftUI
+
+struct DeleteConfirmationView: View {
+    let toDelete: String
+    let toDeleteType: String
+    @Binding var update: Bool
+    let delete: () -> Void
+    
+    @State var message : String = ""
+    
+    var body: some View {
+        ZStack {
+            ZStack(alignment: .topLeading){
+                RoundedRectangle(cornerRadius: 16,style:.continuous)
+                    .strokeBorder(Color.black,lineWidth:2)
+                    .background(Color.white)
+                    .foregroundStyle(.white)
+                    .frame(width: 350, height: 270)
+                ZStack {
+                    RoundedRectangle(cornerRadius: 16, style: .circular)
+                        .frame(width: 350, height: 100)
+                        .foregroundStyle(.black)
+                    Rectangle()
+                        .frame(width:350, height: 20)
+                        .foregroundStyle(.black)
+                        .offset(y:40)
+                }
+                
+            }
+            
+            VStack {
+
+                Text(message)
+                    .font(.system(size:22))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.center)
+                    .bold()
+                    .frame(width:320)
+                    .offset(y:-40)
+                
+                Button {
+                    delete()
+                } label: {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 32)
+                            .foregroundColor(.black)
+                        Text("Confirm")
+                            .foregroundColor(.white)
+                            .font(.system(size:16))
+                            .fontWeight(.bold)
+                    }
+                    .frame(width: 141, height: 45)
+                }
+                
+                Button {
+                    update.toggle()
+                } label: {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 32)
+                            .foregroundColor(.black)
+                        Text("Cancel")
+                            .foregroundColor(.white)
+                            .font(.system(size:16))
+                            .fontWeight(.bold)
+                    }
+                    .frame(width: 141, height: 45)
+                }
+            }
+        }
+        .onAppear {
+            message = (toDeleteType == "Set") ? "Are you sure you want to delete Set \(toDelete)?" : "Are you sure you want to delete the \(toDeleteType), \(toDelete)?"
+        }
+        
+    }
+}
+
+#Preview {
+    DeleteConfirmationView(toDelete: "Arms", toDeleteType: "Workout", update: .constant(true)) {
+    // Delete
+    }
+}

--- a/Sweat Social/Views/WorkoutHelperViews/ExcerciseButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/ExcerciseButtonView.swift
@@ -1,0 +1,82 @@
+//
+//  ExcerciseButtonView.swift
+//  Sweat Social
+//
+//  Created by Jack.Knox on 2024-03-23.
+//
+
+import SwiftUI
+
+struct ExcerciseButtonView: View {
+    @State var sets: Sets?
+    let workout : String
+    let excercise: String
+    
+    let action: (String, @escaping (Sets?) -> Void) -> ()
+    
+    var body: some View {
+        NavigationLink(destination: SetsLogView(workout: workout, excercise: excercise, sets: sets)) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color(hex:0xF4F4F4))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5)
+                            .strokeBorder(Color.black,lineWidth: 2)
+                    )
+                    .frame(width: 153, height: 191)
+                VStack {
+                    Text(excercise)
+                        .foregroundColor(.black)
+                        .font(.system(size:22))
+                        .fontWeight(.bold)
+                        .padding()
+                        
+                    Spacer()
+                    if let sets = sets {
+                        VStack{
+                            if sets.reps.count == 1 {
+                                Text("1 Set")
+                                    .foregroundColor(.black)
+                                    .font(.system(size:16))
+                                    .padding()
+                            } else {
+                                Text("\(sets.reps.count) Sets")
+                                    .foregroundColor(.black)
+                                    .font(.system(size:16))
+                                    .padding()
+                            }
+                       
+                            ForEach(0..<min(sets.reps.count,3), id: \.self) { index in
+                                Text("\(sets.weight[index]) lbs, \(sets.reps[index]) reps")
+                                    .foregroundColor(.black)
+                                    .font(.system(size:16))
+                            }
+                            
+                            if sets.reps.count > 3 {
+                                Text("...")
+                                    .foregroundColor(.black)
+                                    .font(.system(size:16))
+                            }
+                        }
+                        .offset(y:-30)
+                        Spacer()
+                        
+                    }
+                }
+            }
+            .frame(width: 153, height: 191)
+            .padding(4)
+        }
+        .onAppear{
+            action(excercise) { result in
+                sets = result
+            }
+        }
+    }
+}
+
+#Preview {
+    ExcerciseButtonView(workout: "Arms", excercise: "Barbell Curl") {_,_  in 
+        return
+    }
+}

--- a/Sweat Social/Views/WorkoutHelperViews/ExcerciseButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/ExcerciseButtonView.swift
@@ -12,10 +12,12 @@ struct ExcerciseButtonView: View {
     let workout : String
     let excercise: String
     
+    @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
+    
     let action: (String, @escaping (Sets?) -> Void) -> ()
     
     var body: some View {
-        NavigationLink(destination: SetsLogView(workout: workout, excercise: excercise, sets: sets)) {
+        NavigationLink(destination: SetsLogView(workout: workout, excercise: excercise, sets: sets, viewManagerViewModel: viewManagerViewModel)) {
             ZStack {
                 RoundedRectangle(cornerRadius: 5)
                     .fill(Color(hex:0xF4F4F4))
@@ -76,7 +78,7 @@ struct ExcerciseButtonView: View {
 }
 
 #Preview {
-    ExcerciseButtonView(workout: "Arms", excercise: "Barbell Curl") {_,_  in 
+    ExcerciseButtonView(workout: "Arms", excercise: "Barbell Curl", viewManagerViewModel: WorkoutViewManagerViewModel()) {_,_  in
         return
     }
 }

--- a/Sweat Social/Views/WorkoutHelperViews/ExcerciseButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/ExcerciseButtonView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+// View of excercise button, also previews the sets
 struct ExcerciseButtonView: View {
     @State var sets: Sets?
     let workout : String
@@ -20,7 +21,7 @@ struct ExcerciseButtonView: View {
     let action: (String, @escaping (Sets?) -> Void) -> ()
     
     var body: some View {
-        //NavigationLink(destination: SetsLogView(workout: workout, excercise: excercise, sets: sets, viewManagerViewModel: viewManagerViewModel)) {
+        // Logic to trigger delete screen if held, or if tapped, go to set view
         Button{
             if !self.longPress {
                 self.navigate = true
@@ -43,6 +44,7 @@ struct ExcerciseButtonView: View {
                         .padding()
                         
                     Spacer()
+                    // Appropriately display sets in a preview, if they exist
                     if let sets = sets {
                         VStack{
                             if sets.reps.count == 1 {
@@ -75,6 +77,7 @@ struct ExcerciseButtonView: View {
                     }
                 }
                 
+                // Navigates to set view if button is clicked
                 NavigationLink(destination: SetsLogView(workout: workout, excercise: excercise.id, sets: sets, viewManagerViewModel: viewManagerViewModel), isActive: $navigate) {
                     EmptyView()
                         .frame(width:0, height: 0)
@@ -85,11 +88,13 @@ struct ExcerciseButtonView: View {
             .padding(4)
         }
         .onAppear{
+            // Trigger fetch on the excercises sets
             action(excercise.id) { result in
                 sets = result
             }
             
         }
+        // Logic to detetct a hold on button
         .simultaneousGesture(
             LongPressGesture(minimumDuration: 0.7)
                 .onEnded { _ in

--- a/Sweat Social/Views/WorkoutHelperViews/ExcerciseButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/ExcerciseButtonView.swift
@@ -10,14 +10,23 @@ import SwiftUI
 struct ExcerciseButtonView: View {
     @State var sets: Sets?
     let workout : String
-    let excercise: String
+    let excercise: WorkoutExcercise
     
+    @Binding var toDelete: WorkoutExcercise?
     @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
     
+    @State private var navigate = false
+    @State private var longPress = false
     let action: (String, @escaping (Sets?) -> Void) -> ()
     
     var body: some View {
-        NavigationLink(destination: SetsLogView(workout: workout, excercise: excercise, sets: sets, viewManagerViewModel: viewManagerViewModel)) {
+        //NavigationLink(destination: SetsLogView(workout: workout, excercise: excercise, sets: sets, viewManagerViewModel: viewManagerViewModel)) {
+        Button{
+            if !self.longPress {
+                self.navigate = true
+            }
+            self.longPress = false
+        } label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 5)
                     .fill(Color(hex:0xF4F4F4))
@@ -27,10 +36,10 @@ struct ExcerciseButtonView: View {
                     )
                     .frame(width: 153, height: 191)
                 VStack {
-                    Text(excercise)
+                    Text(excercise.id)
                         .foregroundColor(.black)
-                        .font(.system(size:22))
-                        .fontWeight(.bold)
+                        .font(.system(size:20))
+                        //.fontWeight(.bold)
                         .padding()
                         
                     Spacer()
@@ -41,14 +50,14 @@ struct ExcerciseButtonView: View {
                                     .foregroundColor(.black)
                                     .font(.system(size:16))
                                     .padding()
-                            } else {
+                            } else if sets.reps.count != 0{
                                 Text("\(sets.reps.count) Sets")
                                     .foregroundColor(.black)
                                     .font(.system(size:16))
                                     .padding()
                             }
                        
-                            ForEach(0..<min(sets.reps.count,3), id: \.self) { index in
+                            ForEach(0..<min(sets.weight.count,3), id: \.self) { index in
                                 Text("\(sets.weight[index]) lbs, \(sets.reps[index]) reps")
                                     .foregroundColor(.black)
                                     .font(.system(size:16))
@@ -65,20 +74,38 @@ struct ExcerciseButtonView: View {
                         
                     }
                 }
+                
+                NavigationLink(destination: SetsLogView(workout: workout, excercise: excercise.id, sets: sets, viewManagerViewModel: viewManagerViewModel), isActive: $navigate) {
+                    EmptyView()
+                        .frame(width:0, height: 0)
+                        .hidden()
+                }
             }
             .frame(width: 153, height: 191)
             .padding(4)
         }
         .onAppear{
-            action(excercise) { result in
+            action(excercise.id) { result in
                 sets = result
             }
+            
         }
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.7)
+                .onEnded { _ in
+                    self.longPress = true
+                    toDelete = excercise
+                }
+        )
+        
+        
     }
 }
 
 #Preview {
-    ExcerciseButtonView(workout: "Arms", excercise: "Barbell Curl", viewManagerViewModel: WorkoutViewManagerViewModel()) {_,_  in
+    ExcerciseButtonView(workout: "Arms", excercise: WorkoutExcercise(id: "Arms", dateAdded: 10.0),
+                        toDelete: .constant(WorkoutExcercise(id: "Arms", dateAdded: 10.0)),
+                        viewManagerViewModel: WorkoutViewManagerViewModel()) {_,_  in
         return
     }
 }

--- a/Sweat Social/Views/WorkoutHelperViews/ExcerciseButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/ExcerciseButtonView.swift
@@ -100,6 +100,8 @@ struct ExcerciseButtonView: View {
                 .onEnded { _ in
                     self.longPress = true
                     toDelete = excercise
+                    let generator = UIImpactFeedbackGenerator(style: .medium)
+                    generator.impactOccurred()
                 }
         )
         

--- a/Sweat Social/Views/WorkoutHelperViews/SetButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/SetButtonView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+// View for the individual set display
 struct SetButtonView: View {
     let reps: Int
     let weight: Int
@@ -24,7 +25,6 @@ struct SetButtonView: View {
                         .strokeBorder(Color.black, lineWidth: 2)
                 )
                 .frame(width: 367, height: 90)
-                //.padding(4)
 
             HStack {
                 ZStack {
@@ -49,20 +49,20 @@ struct SetButtonView: View {
         .overlay(
             VStack {
                 HStack {
-                    Text("Weight: \(weight)")
+                    Text("Weight: \(weight)") // List weight var
                         .font(.system(size:20))
                     
                 }
                 .padding(2)
                 HStack {
                     Text("Reps: \(reps)")
-                        .font(.system(size:20))
+                        .font(.system(size:20)) // List rep var
                 }
                 .padding(2)
             }
         )
         .padding(2)
-        .onLongPressGesture(minimumDuration: 0.7) {
+        .onLongPressGesture(minimumDuration: 0.7) { // Delete popup triggered on hold
             toDelete = setNum-1
         }
 

--- a/Sweat Social/Views/WorkoutHelperViews/SetButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/SetButtonView.swift
@@ -64,6 +64,8 @@ struct SetButtonView: View {
         .padding(2)
         .onLongPressGesture(minimumDuration: 0.7) { // Delete popup triggered on hold
             toDelete = setNum-1
+            let generator = UIImpactFeedbackGenerator(style: .medium)
+            generator.impactOccurred()
         }
 
         

--- a/Sweat Social/Views/WorkoutHelperViews/SetButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/SetButtonView.swift
@@ -12,11 +12,8 @@ struct SetButtonView: View {
     let weight: Int
     let setNum: Int
     
-    /*init(rep: Int, weight: Int, setNum: Int) {
-        self.setNum = setNum
-        self.rep = rep
-        self.weight = weight
-    }*/
+    @Binding var toDelete: Int?
+    
     
     var body: some View {
         ZStack {
@@ -65,11 +62,14 @@ struct SetButtonView: View {
             }
         )
         .padding(2)
+        .onLongPressGesture(minimumDuration: 0.7) {
+            toDelete = setNum-1
+        }
 
         
     }
 }
 
 #Preview {
-    SetButtonView(reps: 10, weight: 10, setNum: 1)
+    SetButtonView(reps: 10, weight: 10, setNum: 1, toDelete: .constant(nil))
 }

--- a/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 
-
+// View for workout buttons seen on workout log screen
 struct WorkoutGroupButtonView: View {
     let name: WorkoutExcercise
     
@@ -18,6 +18,8 @@ struct WorkoutGroupButtonView: View {
     @State private var longPress = false
     
     var body: some View {
+        // Logic differentiates between a tap and hold. A tap takes you to next view. A hold asks if you want to delete
+        // Label is the view for the button
         Button {
             if !self.longPress {
                 self.navigate = true
@@ -41,6 +43,7 @@ struct WorkoutGroupButtonView: View {
             .frame(width: 367, height: 51)
             .padding(4)
         }
+        // Detect a hold on the button, trigger delete confirmation view
         .simultaneousGesture(
             LongPressGesture(minimumDuration: 0.7)
                 .onEnded { _ in
@@ -50,6 +53,7 @@ struct WorkoutGroupButtonView: View {
         )
         .buttonStyle(PlainButtonStyle())
         
+        // Navigate to next view on tap
         NavigationLink(destination: ExcerciseLogView(workout: name, viewManagerViewModel: viewManagerViewModel), isActive: $navigate) {
             EmptyView()
                 .frame(width:0, height: 0)

--- a/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
@@ -10,13 +10,13 @@ import SwiftUI
 
 
 struct WorkoutGroupButtonView: View {
-    let name: String
-    let workout: String?
+    let name: WorkoutExcercise
+    /*let workout: String?
     let excercisesListed: Bool
-    @State private var showExcercise = false
+    @State private var showExcercise = false*/
     
     var body: some View {
-        NavigationLink(destination: self.destinationView)
+        NavigationLink(destination: ExcerciseLogView(workout: name))
         {
             ZStack {
                 RoundedRectangle(cornerRadius: 25)
@@ -24,10 +24,9 @@ struct WorkoutGroupButtonView: View {
                     .overlay(
                         RoundedRectangle(cornerRadius: 25)
                             .strokeBorder(Color.black, lineWidth: 2)
-                            //.shadow(color: .black.opacity(0.2), radius: 5, x: 0, y: 2)
                     )
                 
-                Text(name)
+                Text(name.id)
                     .foregroundColor(.black)
                     .font(.system(size:16))
                     .fontWeight(.bold)
@@ -38,7 +37,7 @@ struct WorkoutGroupButtonView: View {
         .buttonStyle(PlainButtonStyle()) // Use PlainButtonStyle to remove the default button styling
     }
     
-    private var destinationView: some View {
+    /*private var destinationView: some View {
         if excercisesListed {
             return AnyView(SetsLogView(workout:workout ?? "",excercise: name))
         } else {
@@ -48,9 +47,9 @@ struct WorkoutGroupButtonView: View {
                                   addPlaceHolder: "Enter Exercise",
                                      excercisesListed: true))
         }
-    }
+    }*/
 }
 
 #Preview {
-    WorkoutGroupButtonView(name: "Test", workout: "Biceps", excercisesListed: false)
+    WorkoutGroupButtonView(name: WorkoutExcercise(id: "Arms", dateAdded: 10.0))
 }

--- a/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
@@ -49,6 +49,8 @@ struct WorkoutGroupButtonView: View {
                 .onEnded { _ in
                     self.longPress = true
                     toDelete = name
+                    let generator = UIImpactFeedbackGenerator(style: .medium)
+                    generator.impactOccurred()
                 }
         )
         .buttonStyle(PlainButtonStyle())

--- a/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
@@ -12,13 +12,18 @@ import SwiftUI
 struct WorkoutGroupButtonView: View {
     let name: WorkoutExcercise
     
+    @Binding var toDelete: WorkoutExcercise?
     @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
+    @State private var navigate = false
+    @State private var longPress = false
     
-    let action: (WorkoutExcercise) -> Void
-
     var body: some View {
-        NavigationLink(destination: ExcerciseLogView(workout: name, viewManagerViewModel: viewManagerViewModel))
-        {
+        Button {
+            if !self.longPress {
+                self.navigate = true
+            }
+            self.longPress = false
+        } label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 25)
                     .fill(Color(hex: 0xF4F4F4))
@@ -32,19 +37,29 @@ struct WorkoutGroupButtonView: View {
                     .font(.system(size:16))
                     .fontWeight(.bold)
                 
-                
             }
             .frame(width: 367, height: 51)
             .padding(4)
         }
-        .buttonStyle(PlainButtonStyle()) // Use PlainButtonStyle to remove the default button styling
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.7)
+                .onEnded { _ in
+                    self.longPress = true
+                    toDelete = name
+                }
+        )
+        .buttonStyle(PlainButtonStyle())
         
+        NavigationLink(destination: ExcerciseLogView(workout: name, viewManagerViewModel: viewManagerViewModel), isActive: $navigate) {
+            EmptyView()
+                .frame(width:0, height: 0)
+                .hidden()
+        }
+
     }
     
 }
 
 #Preview {
-    WorkoutGroupButtonView(name: WorkoutExcercise(id: "Arms", dateAdded: 10.0) , viewManagerViewModel: WorkoutViewManagerViewModel()) { _ in
-    //
-    }
+    WorkoutGroupButtonView(name: WorkoutExcercise(id: "Arms", dateAdded: 10.0), toDelete: .constant(WorkoutExcercise(id: "Arms", dateAdded: 10.0)), viewManagerViewModel: WorkoutViewManagerViewModel())
 }

--- a/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
@@ -13,6 +13,8 @@ struct WorkoutGroupButtonView: View {
     let name: WorkoutExcercise
     
     @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
+    
+    let action: (WorkoutExcercise) -> Void
 
     var body: some View {
         NavigationLink(destination: ExcerciseLogView(workout: name, viewManagerViewModel: viewManagerViewModel))
@@ -29,15 +31,20 @@ struct WorkoutGroupButtonView: View {
                     .foregroundColor(.black)
                     .font(.system(size:16))
                     .fontWeight(.bold)
+                
+                
             }
             .frame(width: 367, height: 51)
             .padding(4)
         }
         .buttonStyle(PlainButtonStyle()) // Use PlainButtonStyle to remove the default button styling
+        
     }
     
 }
 
 #Preview {
-    WorkoutGroupButtonView(name: WorkoutExcercise(id: "Arms", dateAdded: 10.0), viewManagerViewModel: WorkoutViewManagerViewModel())
+    WorkoutGroupButtonView(name: WorkoutExcercise(id: "Arms", dateAdded: 10.0) , viewManagerViewModel: WorkoutViewManagerViewModel()) { _ in
+    //
+    }
 }

--- a/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/WorkoutGroupButtonView.swift
@@ -11,12 +11,11 @@ import SwiftUI
 
 struct WorkoutGroupButtonView: View {
     let name: WorkoutExcercise
-    /*let workout: String?
-    let excercisesListed: Bool
-    @State private var showExcercise = false*/
     
+    @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
+
     var body: some View {
-        NavigationLink(destination: ExcerciseLogView(workout: name))
+        NavigationLink(destination: ExcerciseLogView(workout: name, viewManagerViewModel: viewManagerViewModel))
         {
             ZStack {
                 RoundedRectangle(cornerRadius: 25)
@@ -37,19 +36,8 @@ struct WorkoutGroupButtonView: View {
         .buttonStyle(PlainButtonStyle()) // Use PlainButtonStyle to remove the default button styling
     }
     
-    /*private var destinationView: some View {
-        if excercisesListed {
-            return AnyView(SetsLogView(workout:workout ?? "",excercise: name))
-        } else {
-            return AnyView(WorkoutLogView(title: "Your \(name) Exercises",
-                                  workoutSelected: name,
-                                  addMainTitle: "Enter Exercise",
-                                  addPlaceHolder: "Enter Exercise",
-                                     excercisesListed: true))
-        }
-    }*/
 }
 
 #Preview {
-    WorkoutGroupButtonView(name: WorkoutExcercise(id: "Arms", dateAdded: 10.0))
+    WorkoutGroupButtonView(name: WorkoutExcercise(id: "Arms", dateAdded: 10.0), viewManagerViewModel: WorkoutViewManagerViewModel())
 }

--- a/Sweat Social/Views/WorkoutHelperViews/WorkoutHeaderView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/WorkoutHeaderView.swift
@@ -10,32 +10,36 @@ import SwiftUI
 struct WorkoutHeaderView: View {
     @Binding var showAddWorkoutForm: Bool
     let title: String
+    let backButton: Bool
     
     @Environment(\.presentationMode) private var
         presentationMode: Binding<PresentationMode>
     
     var body: some View {
         HStack{
-            Button {
-                presentationMode.wrappedValue
-                    .dismiss()
-            } label: {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 15)
-                        .foregroundColor(.black)
-                    Text("<-")
-                        .foregroundColor(.white)
-                        .font(.system(size: 20))
-                        .fontWeight(.bold)
+            if(backButton){
+                Button {
+                    presentationMode.wrappedValue
+                        .dismiss()
+                } label: {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 15)
+                            .foregroundColor(.black)
+                        Text("<-")
+                            .foregroundColor(.white)
+                            .font(.system(size: 20))
+                            .fontWeight(.bold)
+                    }
+                    .frame(width: 39, height: 26)
+                    .padding()
+                    
                 }
-                .frame(width: 39, height: 26)
-                .padding()
-                
             }
             
             Text(title)
                 .frame(maxWidth: .infinity, alignment: .center)
                 .font(.system(size:24))
+                .padding(.leading, backButton ? 0 : UIScreen.main.bounds.width / 6)
             
             //HStack {
                 //Spacer()
@@ -60,5 +64,5 @@ struct WorkoutHeaderView: View {
 }
 
 #Preview {
-    WorkoutHeaderView(showAddWorkoutForm: .constant(true), title: "Your workout")
+    WorkoutHeaderView(showAddWorkoutForm: .constant(true), title: "Your workout", backButton: true)
 }

--- a/Sweat Social/Views/WorkoutHelperViews/WorkoutHeaderView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/WorkoutHeaderView.swift
@@ -22,10 +22,10 @@ struct WorkoutHeaderView: View {
                     ZStack {
                         RoundedRectangle(cornerRadius: 15)
                             .foregroundColor(.black)
-                        Text("<-")
+                        Image(systemName: "arrow.left")
                             .foregroundColor(.white)
                             .font(.system(size: 20))
-                            .fontWeight(.bold)
+                            //.fontWeight(.bold)
                     }
                     .frame(width: 39, height: 26)
                     .padding()

--- a/Sweat Social/Views/WorkoutHelperViews/WorkoutHeaderView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/WorkoutHeaderView.swift
@@ -10,11 +10,15 @@ import SwiftUI
 struct WorkoutHeaderView: View {
     @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
     
+    /*
     @Environment(\.presentationMode) private var
         presentationMode: Binding<PresentationMode>
+     */
     
     var body: some View {
         HStack{
+            // Checks to see if back button should be displayed. WorkoutLog will not have it, as it is the first screen
+            // View for back button
             if(viewManagerViewModel.backButton){
                 Button {
                     viewManagerViewModel.dismiss.toggle()
@@ -34,12 +38,13 @@ struct WorkoutHeaderView: View {
                 
             }
                 
-            
+            // Displays title in top center of the screen. Controller by viewManagerViewModel
             Text(viewManagerViewModel.title)
                 .frame(maxWidth: .infinity, alignment: .center)
                 .font(.system(size:24))
                 .padding(.leading, viewManagerViewModel.backButton ? 0 : UIScreen.main.bounds.width / 6)
             
+            // Add button, toggle the add form variable which will display a popup on respective view
             Button {
                 viewManagerViewModel.addForm.toggle()
             } label: {

--- a/Sweat Social/Views/WorkoutHelperViews/WorkoutHeaderView.swift
+++ b/Sweat Social/Views/WorkoutHelperViews/WorkoutHeaderView.swift
@@ -8,19 +8,16 @@
 import SwiftUI
 
 struct WorkoutHeaderView: View {
-    @Binding var showAddWorkoutForm: Bool
-    let title: String
-    let backButton: Bool
+    @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
     
     @Environment(\.presentationMode) private var
         presentationMode: Binding<PresentationMode>
     
     var body: some View {
         HStack{
-            if(backButton){
+            if(viewManagerViewModel.backButton){
                 Button {
-                    presentationMode.wrappedValue
-                        .dismiss()
+                    viewManagerViewModel.dismiss.toggle()
                 } label: {
                     ZStack {
                         RoundedRectangle(cornerRadius: 15)
@@ -34,17 +31,17 @@ struct WorkoutHeaderView: View {
                     .padding()
                     
                 }
+                
             }
+                
             
-            Text(title)
+            Text(viewManagerViewModel.title)
                 .frame(maxWidth: .infinity, alignment: .center)
                 .font(.system(size:24))
-                .padding(.leading, backButton ? 0 : UIScreen.main.bounds.width / 6)
+                .padding(.leading, viewManagerViewModel.backButton ? 0 : UIScreen.main.bounds.width / 6)
             
-            //HStack {
-                //Spacer()
             Button {
-                showAddWorkoutForm.toggle()
+                viewManagerViewModel.addForm.toggle()
             } label: {
                 ZStack {
                     RoundedRectangle(cornerRadius: 15)
@@ -58,11 +55,10 @@ struct WorkoutHeaderView: View {
                 .padding()
                 
             }
-           // }
         }
     }
 }
 
 #Preview {
-    WorkoutHeaderView(showAddWorkoutForm: .constant(true), title: "Your workout", backButton: true)
+    WorkoutHeaderView(viewManagerViewModel: WorkoutViewManagerViewModel())
 }

--- a/Sweat Social/Views/WorkoutLogView.swift
+++ b/Sweat Social/Views/WorkoutLogView.swift
@@ -8,49 +8,38 @@
 import SwiftUI
 
 struct WorkoutLogView: View {
-    let title: String
-    let workoutSelected: String? // Value if user clicks a workout, and goes to excercise page
-    
-    // Variables on addForm
-    let addMainTitle: String
-    let addPlaceHolder: String
-    
-    let excercisesListed: Bool
-    
-    @StateObject var viewModel : WorkoutLogViewModel
-    
-    init(title: String, workoutSelected: String?, addMainTitle: String, addPlaceHolder: String, excercisesListed: Bool) {
-        self.title = title
-        self.workoutSelected = workoutSelected
-        self.addMainTitle = addMainTitle
-        self.addPlaceHolder = addPlaceHolder
-        self.excercisesListed = excercisesListed
-        self._viewModel = StateObject(wrappedValue: WorkoutLogViewModel(workout: workoutSelected))
-    }
+
+    @StateObject var viewModel = WorkoutLogViewModel()
     
     var body: some View {
         NavigationStack {
             VStack {
                 ZStack {
                     VStack {
-                        WorkoutHeaderView(showAddWorkoutForm: $viewModel.addWorkoutForm, title: title)
+                        WorkoutHeaderView(showAddWorkoutForm: $viewModel.addWorkoutForm, title: "Your Workout")
                         
                         ScrollView {
                             ForEach(viewModel.workoutList) { group in
-                                WorkoutGroupButtonView(name: group.id, workout: workoutSelected, excercisesListed: self.excercisesListed)
+                                WorkoutGroupButtonView(name: group)
                             }
                         }
                     }
 
                     if viewModel.addWorkoutForm {
                         ZStack {
-                            AddWorkoutView(showAddWorkoutForm: $viewModel.addWorkoutForm, workoutSelected: workoutSelected, mainTitle: addMainTitle, placeHolder: addPlaceHolder, action: viewModel.addWorkout)
+                            AddWorkoutView(showAddWorkoutForm: $viewModel.addWorkoutForm,
+                                           mainTitle: "Add Workout",
+                                           placeHolder: "Enter Workout",
+                                           action: viewModel.addWorkout)
                         }
                     }
                     
                 }
             }
             .padding(.top,40)
+            .onAppear{
+                viewModel.fetchWorkouts()
+            }
         }
         .navigationBarHidden(true)
         
@@ -58,5 +47,5 @@ struct WorkoutLogView: View {
 }
 
 #Preview {
-    WorkoutLogView(title: "Your Workout", workoutSelected: nil, addMainTitle: "Enter workout", addPlaceHolder: "Add Excercise", excercisesListed: false)
+    WorkoutLogView()
 }

--- a/Sweat Social/Views/WorkoutLogView.swift
+++ b/Sweat Social/Views/WorkoutLogView.swift
@@ -7,14 +7,16 @@
 
 import SwiftUI
 
+// This is the main workout category log view.
 struct WorkoutLogView: View {
-    @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
+    @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel // viewModel to control header
     
-    @StateObject var viewModel = WorkoutLogViewModel()
+    @StateObject var viewModel = WorkoutLogViewModel() // viewModel to manage workout log
     
     var body: some View {
         NavigationStack{
             ZStack {
+                // Create a scroll view of workout buttons
                 ScrollView {
                     ForEach(viewModel.workoutList) { group in
                         WorkoutGroupButtonView(name: group,
@@ -23,7 +25,7 @@ struct WorkoutLogView: View {
                     }
                 }
                 
-                
+                // Check to see if add form is clicked, and display form if so
                 if viewManagerViewModel.addForm {
                     ZStack {
                         AddWorkoutView(showAddWorkoutForm: $viewManagerViewModel.addForm,
@@ -35,13 +37,14 @@ struct WorkoutLogView: View {
                     }
                 }
                 
+                // Check to see if delete is enabled, and show confirm screen if so
                 if let toDelete = viewModel.toDelete {
                     DeleteConfirmationView(toDelete: toDelete.id,
                                            toDeleteType: "workout",
                                            update: $viewModel.deleteSuccess,
                                            delete: viewModel.deleteWorkout)
                     .onChange(of: viewModel.deleteSuccess) { _ in
-                        viewModel.toDelete = nil
+                        viewModel.toDelete = nil // This removes popup if cancel is pressed
                     }
                     
                 }

--- a/Sweat Social/Views/WorkoutLogView.swift
+++ b/Sweat Social/Views/WorkoutLogView.swift
@@ -25,6 +25,8 @@ struct WorkoutLogView: View {
                 if viewManagerViewModel.addForm {
                     ZStack {
                         AddWorkoutView(showAddWorkoutForm: $viewManagerViewModel.addForm,
+                                       errorMessage: $viewModel.errorMessage,
+                                       workoutList: $viewModel.workoutList,
                                        mainTitle: "Add Workout",
                                        placeHolder: "Enter Workout",
                                        action: viewModel.addWorkout)

--- a/Sweat Social/Views/WorkoutLogView.swift
+++ b/Sweat Social/Views/WorkoutLogView.swift
@@ -16,7 +16,7 @@ struct WorkoutLogView: View {
             VStack {
                 ZStack {
                     VStack {
-                        WorkoutHeaderView(showAddWorkoutForm: $viewModel.addWorkoutForm, title: "Your Workout")
+                        WorkoutHeaderView(showAddWorkoutForm: $viewModel.addWorkoutForm, title: "Your Workout",backButton: false)
                         
                         ScrollView {
                             ForEach(viewModel.workoutList) { group in

--- a/Sweat Social/Views/WorkoutLogView.swift
+++ b/Sweat Social/Views/WorkoutLogView.swift
@@ -8,35 +8,32 @@
 import SwiftUI
 
 struct WorkoutLogView: View {
-
+    @Binding var addForm: Bool
+    @Binding var title: String
+    @Binding var backButton: Bool
+    
     @StateObject var viewModel = WorkoutLogViewModel()
     
     var body: some View {
         NavigationStack {
-            VStack {
-                ZStack {
-                    VStack {
-                        WorkoutHeaderView(showAddWorkoutForm: $viewModel.addWorkoutForm, title: "Your Workout",backButton: false)
-                        
-                        ScrollView {
-                            ForEach(viewModel.workoutList) { group in
-                                WorkoutGroupButtonView(name: group)
-                            }
-                        }
+            ZStack {
+                ScrollView {
+                    ForEach(viewModel.workoutList) { group in
+                        WorkoutGroupButtonView(name: group)
                     }
-
-                    if viewModel.addWorkoutForm {
-                        ZStack {
-                            AddWorkoutView(showAddWorkoutForm: $viewModel.addWorkoutForm,
-                                           mainTitle: "Add Workout",
-                                           placeHolder: "Enter Workout",
-                                           action: viewModel.addWorkout)
-                        }
+                }
+                
+                
+                if addForm {
+                    ZStack {
+                        AddWorkoutView(showAddWorkoutForm: $addForm,
+                                       mainTitle: "Add Workout",
+                                       placeHolder: "Enter Workout",
+                                       action: viewModel.addWorkout)
                     }
-                    
                 }
             }
-            .padding(.top,40)
+            //.padding(.top,40)
             .onAppear{
                 viewModel.fetchWorkouts()
             }
@@ -47,5 +44,5 @@ struct WorkoutLogView: View {
 }
 
 #Preview {
-    WorkoutLogView()
+    WorkoutLogView(addForm: .constant(true))
 }

--- a/Sweat Social/Views/WorkoutLogView.swift
+++ b/Sweat Social/Views/WorkoutLogView.swift
@@ -17,7 +17,9 @@ struct WorkoutLogView: View {
             ZStack {
                 ScrollView {
                     ForEach(viewModel.workoutList) { group in
-                        WorkoutGroupButtonView(name: group, viewManagerViewModel: viewManagerViewModel, action: viewModel.deleteWorkout)
+                        WorkoutGroupButtonView(name: group,
+                                               toDelete: $viewModel.toDelete,
+                                               viewManagerViewModel: viewManagerViewModel)
                     }
                 }
                 
@@ -31,6 +33,17 @@ struct WorkoutLogView: View {
                                        placeHolder: "Enter Workout",
                                        action: viewModel.addWorkout)
                     }
+                }
+                
+                if let toDelete = viewModel.toDelete {
+                    DeleteConfirmationView(toDelete: toDelete.id,
+                                           toDeleteType: "workout",
+                                           update: $viewModel.deleteSuccess,
+                                           delete: viewModel.deleteWorkout)
+                    .onChange(of: viewModel.deleteSuccess) { _ in
+                        viewModel.toDelete = nil
+                    }
+                    
                 }
             }
             .onAppear{

--- a/Sweat Social/Views/WorkoutLogView.swift
+++ b/Sweat Social/Views/WorkoutLogView.swift
@@ -17,7 +17,7 @@ struct WorkoutLogView: View {
             ZStack {
                 ScrollView {
                     ForEach(viewModel.workoutList) { group in
-                        WorkoutGroupButtonView(name: group, viewManagerViewModel: viewManagerViewModel)
+                        WorkoutGroupButtonView(name: group, viewManagerViewModel: viewManagerViewModel, action: viewModel.deleteWorkout)
                     }
                 }
                 

--- a/Sweat Social/Views/WorkoutLogView.swift
+++ b/Sweat Social/Views/WorkoutLogView.swift
@@ -8,32 +8,29 @@
 import SwiftUI
 
 struct WorkoutLogView: View {
-    @Binding var addForm: Bool
-    @Binding var title: String
-    @Binding var backButton: Bool
+    @ObservedObject var viewManagerViewModel: WorkoutViewManagerViewModel
     
     @StateObject var viewModel = WorkoutLogViewModel()
     
     var body: some View {
-        NavigationStack {
+        NavigationStack{
             ZStack {
                 ScrollView {
                     ForEach(viewModel.workoutList) { group in
-                        WorkoutGroupButtonView(name: group)
+                        WorkoutGroupButtonView(name: group, viewManagerViewModel: viewManagerViewModel)
                     }
                 }
                 
                 
-                if addForm {
+                if viewManagerViewModel.addForm {
                     ZStack {
-                        AddWorkoutView(showAddWorkoutForm: $addForm,
+                        AddWorkoutView(showAddWorkoutForm: $viewManagerViewModel.addForm,
                                        mainTitle: "Add Workout",
                                        placeHolder: "Enter Workout",
                                        action: viewModel.addWorkout)
                     }
                 }
             }
-            //.padding(.top,40)
             .onAppear{
                 viewModel.fetchWorkouts()
             }
@@ -44,5 +41,5 @@ struct WorkoutLogView: View {
 }
 
 #Preview {
-    WorkoutLogView(addForm: .constant(true))
+    WorkoutLogView(viewManagerViewModel: WorkoutViewManagerViewModel())
 }

--- a/Sweat Social/Views/WorkoutViewManagerView.swift
+++ b/Sweat Social/Views/WorkoutViewManagerView.swift
@@ -8,16 +8,20 @@
 import SwiftUI
 
 struct WorkoutViewManagerView: View {
-    @State var addForm = false
-    @State var title = "Your Workout"
-    @State var backButton = false
+    @StateObject var viewManagerViewModel = WorkoutViewManagerViewModel()
+    
     
     var body: some View {
         VStack {
-            WorkoutHeaderView(showAddWorkoutForm: $addForm, title: title,backButton: backButton)
+            WorkoutHeaderView(viewManagerViewModel: viewManagerViewModel)
                 .padding(.top,40)
             
-            WorkoutLogView(addForm: $addForm, title: $title, backButton: $backButton)
+            NavigationStack{
+                WorkoutLogView(viewManagerViewModel: viewManagerViewModel)
+            }
+            
+            .navigationBarHidden(true)
+        
         }
     }
 }

--- a/Sweat Social/Views/WorkoutViewManagerView.swift
+++ b/Sweat Social/Views/WorkoutViewManagerView.swift
@@ -1,0 +1,27 @@
+//
+//  WorkoutViewManagerView.swift
+//  Sweat Social
+//
+//  Created by Jack.Knox on 2024-03-24.
+//
+
+import SwiftUI
+
+struct WorkoutViewManagerView: View {
+    @State var addForm = false
+    @State var title = "Your Workout"
+    @State var backButton = false
+    
+    var body: some View {
+        VStack {
+            WorkoutHeaderView(showAddWorkoutForm: $addForm, title: title,backButton: backButton)
+                .padding(.top,40)
+            
+            WorkoutLogView(addForm: $addForm, title: $title, backButton: $backButton)
+        }
+    }
+}
+
+#Preview {
+    WorkoutViewManagerView()
+}

--- a/Sweat Social/Views/WorkoutViewManagerView.swift
+++ b/Sweat Social/Views/WorkoutViewManagerView.swift
@@ -7,15 +7,18 @@
 
 import SwiftUI
 
+// View Controller for the entire workout view stack. Constists of WorkoutView, ExcerciseView, and SetView
+// Main purpose is to have one header view. Leads to better UI and also more abstracted code
 struct WorkoutViewManagerView: View {
     @StateObject var viewManagerViewModel = WorkoutViewManagerViewModel()
     
-    
     var body: some View {
         VStack {
+            //Main feature, sets the title, and add/back buttons. The viewManagerViewModel controls the title and other variation
             WorkoutHeaderView(viewManagerViewModel: viewManagerViewModel)
                 .padding(.top,40)
             
+            //Beginning of workout navigation stack, first is the Workout log view.
             NavigationStack{
                 WorkoutLogView(viewManagerViewModel: viewManagerViewModel)
             }


### PR DESCRIPTION
This is the first fully functional version of the workout logging system. This builds on the previous PRs by editing the exercise UI, adding validation, adding deletion, and reorganizing code to increase readability.

The format of the code is as followed. There is a WorkoutViewManagerView, which controls the title, add, and back buttons across all of the views, and displays the appropriate view below it. The 3 views that are used are the WorkoutLogView, ExcerciseLogView, and SetLogView. They are navigated to in that order, by hitting one of the buttons in its respective view. By hitting the back button at the top, you can move backwards as well. 

There are also helper views, such as an add workout popup, and a delete workout popup. To reach the add workout popup, hit the add button in the top right. To delete an item, hold its button, and hit confirm. There are also helper views for each button, to increase organization.

Each main view has its own view model, which contains the majority of the functions and logic. These view models use dependency injection to connect to the Firestore api, which talks to firestore.